### PR TITLE
Feature/#19 verilog parser

### DIFF
--- a/ophidian/CMakeLists.txt
+++ b/ophidian/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_subdirectory(entity_system)
 add_subdirectory(circuit)
-
+add_subdirectory(parser)

--- a/ophidian/circuit/CMakeLists.txt
+++ b/ophidian/circuit/CMakeLists.txt
@@ -3,6 +3,5 @@ file(GLOB ophidian_circuit_SRC
     "*.cpp"
 )
 add_library(ophidian_circuit ${ophidian_circuit_SRC})
-target_link_libraries(ophidian_circuit PUBLIC verilogparser)
 install(TARGETS ophidian_circuit DESTINATION lib)
 install(FILES Netlist.h DESTINATION include/ophidian/circuit)

--- a/ophidian/parser/CMakeLists.txt
+++ b/ophidian/parser/CMakeLists.txt
@@ -5,4 +5,4 @@ file(GLOB ophidian_parser_SRC
 add_library(ophidian_parser ${ophidian_parser_SRC})
 target_link_libraries(ophidian_parser PUBLIC verilogparser)
 install(TARGETS ophidian_parser DESTINATION lib)
-install(FILES Netlist.h DESTINATION include/ophidian/parser)
+install(FILES VerilogParser.h DESTINATION include/ophidian/parser)

--- a/ophidian/parser/CMakeLists.txt
+++ b/ophidian/parser/CMakeLists.txt
@@ -1,0 +1,8 @@
+file(GLOB ophidian_parser_SRC
+    "*.h"
+    "*.cpp"
+)
+add_library(ophidian_parser ${ophidian_parser_SRC})
+target_link_libraries(ophidian_parser PUBLIC verilogparser)
+install(TARGETS ophidian_parser DESTINATION lib)
+install(FILES Netlist.h DESTINATION include/ophidian/parser)

--- a/ophidian/parser/VerilogParser.cpp
+++ b/ophidian/parser/VerilogParser.cpp
@@ -1,0 +1,148 @@
+#include "VerilogParser.h"
+#include <3rdparty/verilog-parser/src/verilog_parser.h>
+
+namespace ophidian
+{
+namespace parser
+{
+
+Verilog::Module* Verilog::addModule(const std::string &name)
+{
+    Module module(name);
+    modules_.push_back(module);
+    return &modules_.back();
+}
+
+const std::list<Verilog::Module> &Verilog::modules() const
+{
+    return modules_;
+}
+
+VerilogParser::VerilogParser()
+{
+
+}
+
+Verilog* VerilogParser::readStream(std::istream &in)
+{
+    auto input = std::make_unique<Verilog>();
+
+    return input.release();
+}
+
+Verilog::Module::Module(const std::string &name)
+{
+    name_ = name;
+}
+
+Verilog::Port* Verilog::Module::addPort(Verilog::PortDirection direction, const std::string name)
+{
+    Port p(direction, name);
+    ports_.push_back(p);
+    return &ports_.back();
+}
+
+Verilog::Net *Verilog::Module::addNet(const std::string &name)
+{
+    Net n(name);
+    nets_.push_back(n);
+    return &nets_.back();
+}
+
+Verilog::Module *Verilog::Module::addModule(const std::string &name)
+{
+    Module m(name);
+    modules_.push_back(m);
+    return &modules_.back();
+}
+
+Verilog::Instance *Verilog::Module::addInstance(Verilog::Module *module, const std::string &name)
+{
+    Instance inst(module, name);
+    instances_.push_back(inst);
+    return &instances_.back();
+}
+
+const std::string &Verilog::Module::name() const
+{
+    return name_;
+
+}
+
+const std::list<Verilog::Port> &Verilog::Module::ports() const
+{
+    return ports_;
+}
+
+const std::list<Verilog::Net> &Verilog::Module::nets() const
+{
+    return nets_;
+}
+
+const std::list<Verilog::Module> &Verilog::Module::modules() const
+{
+    return modules_;
+}
+
+const std::list<Verilog::Instance> &Verilog::Module::instances() const
+{
+    return instances_;
+}
+
+Verilog::Port::Port(Verilog::PortDirection direction, const std::string &name) :
+    direction_(direction),
+    name_(name)
+{
+}
+
+Verilog::PortDirection Verilog::Port::direction() const
+{
+    return direction_;
+}
+
+const std::string &Verilog::Port::name() const
+{
+    return name_;
+}
+
+Verilog::Net::Net(const std::string &name) :
+    name_(name)
+{
+
+}
+
+const std::string &Verilog::Net::name() const
+{
+    return name_;
+}
+
+Verilog::Instance::Instance(Verilog::Module *module, const std::string name):
+    module_(module),
+    name_(name)
+{
+
+}
+
+Verilog::Module *Verilog::Instance::module() const
+{
+    return module_;
+}
+
+const std::string &Verilog::Instance::name() const
+{
+    return name_;
+}
+
+void Verilog::Instance::mapPort(Verilog::Port *port, Verilog::Net *net)
+{
+    portMapping_[port] = net;
+}
+
+const std::map<Verilog::Port *, Verilog::Net *> &Verilog::Instance::portMapping() const
+{
+    return portMapping_;
+}
+
+}
+}
+

--- a/ophidian/parser/VerilogParser.cpp
+++ b/ophidian/parser/VerilogParser.cpp
@@ -1,10 +1,37 @@
 #include "VerilogParser.h"
+
+#include <vector>
+#include <unordered_map>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include <3rdparty/verilog-parser/src/verilog_parser.h>
+#include <3rdparty/verilog-parser/src/verilog_ast_util.h>
+#ifdef __cplusplus
+}
+#endif
 
 namespace ophidian
 {
 namespace parser
 {
+
+namespace
+{
+
+using ModuleDeclaration = ast_module_declaration;
+using ModuleInst = ast_module_instantiation;
+using ModuleInstance = ast_module_instance;
+using ListElement = ast_list_element;
+using PortDeclaration = ast_port_declaration;
+using Identifier = ast_identifier;
+using PortConnection = ast_port_connection;
+using Expression = ast_expression;
+using NetDeclaration = ast_net_declaration;
+using PortDirection = ast_port_direction;
+
+}
 
 Verilog::Module* Verilog::addModule(const std::string &name)
 {
@@ -18,16 +45,119 @@ const std::list<Verilog::Module> &Verilog::modules() const
     return modules_;
 }
 
-VerilogParser::VerilogParser()
+struct VerilogParser::Impl
+{
+    Impl()
+    {
+        directionMapping[PORT_INPUT] = Verilog::PortDirection::INPUT;
+        directionMapping[PORT_OUTPUT] = Verilog::PortDirection::OUTPUT;
+        directionMapping[PORT_INOUT] = Verilog::PortDirection::INOUT;
+        directionMapping[PORT_NONE] = Verilog::PortDirection::NONE;
+    }
+
+    std::map<PortDirection, Verilog::PortDirection> directionMapping;
+};
+
+VerilogParser::VerilogParser() :
+    this_(new Impl)
+{
+
+}
+
+VerilogParser::~VerilogParser()
 {
 
 }
 
 Verilog* VerilogParser::readStream(std::istream &in)
 {
-    auto input = std::make_unique<Verilog>();
+    verilog_parser_init();
+    std::vector<char> buffer((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    int result = verilog_parse_string(buffer.data(), buffer.size());
 
-    return input.release();
+    if (result)
+    {
+        return nullptr;
+    }
+
+    auto inp = std::make_unique<Verilog>();
+    Verilog* verilog = inp.get();
+    auto source = yy_verilog_source_tree;
+    ModuleDeclaration* vModule = static_cast<ModuleDeclaration*>(ast_list_get(source -> modules, 0));
+    auto module = verilog->addModule(vModule->identifier->identifier);
+
+    std::unordered_map<std::string, Verilog::Net*> netMapping;
+    for(ListElement * i = vModule->net_declarations->head; i; i = i->next)
+    {
+        NetDeclaration* verilogNet = static_cast<NetDeclaration*>(i->data);
+        const std::string netName(verilogNet->identifier->identifier);
+        if(netMapping.count(netName) == 0)
+        {
+            netMapping[netName] = module->addNet(netName);
+        }
+    }
+
+    for( ListElement* i = vModule->module_ports->head; i; i = i->next)
+    {
+        PortDeclaration* vPort = static_cast<PortDeclaration*>(i->data);
+        auto direction = this_->directionMapping.at(vPort->direction);
+        for(ListElement* portNameWalker = vPort->port_names->head; portNameWalker; portNameWalker = portNameWalker->next)
+        {
+            Identifier identifier = static_cast<Identifier>(portNameWalker->data);
+            module->addPort(direction, identifier->identifier);
+        }
+    }
+
+    std::unordered_map<std::string, Verilog::Module*> moduleMapping;
+    for(ListElement* i =  vModule->module_instantiations->head; i; i = i->next)
+    {
+        ModuleInst* vInstanciation = static_cast<ModuleInst*>(i->data);
+        const std::string moduleId = vInstanciation->module_identifer->identifier;
+        if(moduleMapping.count(moduleId) == 0)
+        {
+            moduleMapping[moduleId] = module->addModule(moduleId);
+        }
+        Verilog::Module * theModule = moduleMapping.at(moduleId);
+        for(ListElement* j = vInstanciation->module_instances->head; j; j = j->next)
+        {
+            ModuleInstance* vInstance = static_cast<ModuleInstance*>(j->data);
+            Verilog::Instance * instance = module->addInstance(theModule, vInstance->instance_identifier->identifier);
+            for(ListElement * k =  vInstance->port_connections->head; k; k = k->next)
+            {
+                PortConnection* vConnection = static_cast<PortConnection*>(k->data);
+                Expression* exp = vConnection->expression;
+                const std::string portName = vConnection->port_name->identifier;
+                const std::string netName = exp->primary->value.identifier->identifier;
+                const Verilog::Port * port = nullptr;
+                for(auto const & currPort : theModule->ports())
+                {
+                    if(currPort.name() == portName)
+                    {
+                        port = &currPort;
+                        break;
+                    }
+                }
+                if(!port)
+                {
+                    port = theModule->addPort(Verilog::PortDirection::NONE, portName);
+                }
+                auto netIt = netMapping.find(netName);
+                if(netIt == netMapping.end())
+                {
+                    netIt = netMapping.insert(netIt, std::make_pair(netName, module->addNet(netName)));
+                }
+                const Verilog::Net * net = netIt->second;
+                instance->mapPort(port, net);
+            }
+        }
+    }
+
+    // TODO: verify how to free the syntax tree.
+    yy_preproc = nullptr;
+    yy_verilog_source_tree = nullptr;
+
+    ast_free_all();
+    return inp.release();
 }
 
 Verilog::Module::Module(const std::string &name)
@@ -105,6 +235,11 @@ const std::string &Verilog::Port::name() const
     return name_;
 }
 
+bool Verilog::Port::operator==(const Verilog::Port &o) const
+{
+    return name_ == o.name_ && direction_ == o.direction_;
+}
+
 Verilog::Net::Net(const std::string &name) :
     name_(name)
 {
@@ -114,6 +249,11 @@ Verilog::Net::Net(const std::string &name) :
 const std::string &Verilog::Net::name() const
 {
     return name_;
+}
+
+bool Verilog::Net::operator==(const Verilog::Net &o) const
+{
+    return name_ == o.name_;
 }
 
 Verilog::Instance::Instance(Verilog::Module *module, const std::string name):
@@ -133,12 +273,12 @@ const std::string &Verilog::Instance::name() const
     return name_;
 }
 
-void Verilog::Instance::mapPort(Verilog::Port *port, Verilog::Net *net)
+void Verilog::Instance::mapPort(const Verilog::Port *port, const Verilog::Net *net)
 {
     portMapping_[port] = net;
 }
 
-const std::map<Verilog::Port *, Verilog::Net *> &Verilog::Instance::portMapping() const
+const std::map<const Verilog::Port *, const Verilog::Net *> &Verilog::Instance::portMapping() const
 {
     return portMapping_;
 }

--- a/ophidian/parser/VerilogParser.h
+++ b/ophidian/parser/VerilogParser.h
@@ -17,7 +17,8 @@ public:
     {
         INPUT,
         OUTPUT,
-        INOUT
+        INOUT,
+        NONE
     };
 
     class Port
@@ -26,6 +27,7 @@ public:
         Port(PortDirection direction, const std::string &name);
         PortDirection direction() const;
         const std::string &name() const;
+        bool operator==(const Port& o) const;
     private:
         PortDirection direction_;
         std::string name_;
@@ -36,6 +38,7 @@ public:
     public:
         Net(const std::string & name);
         const std::string& name() const;
+        bool operator==(const Net& o) const;
     private:
         std::string name_;
     };
@@ -47,13 +50,13 @@ public:
         Instance(Module * module, const std::string name);
         Module * module() const;
         const std::string & name() const;
-        void mapPort(Port* port, Net * net);
-        const std::map<Port*, Net*> & portMapping() const;
+        void mapPort(const Port *port, const Net *net);
+        const std::map<const Port*, const Net*> & portMapping() const;
 
     private:
         Module * module_;
         std::string name_;
-        std::map<Port*, Net*> portMapping_;
+        std::map<const Port*, const Net*> portMapping_;
     };
 
     class Module
@@ -71,9 +74,9 @@ public:
         const std::list<Net> & nets() const;
         const std::list<Module> &modules() const;
         const std::list<Instance> & instances() const;
+
     private:
         std::string name_;
-
         std::list<Port> ports_;
         std::list<Net> nets_;
         std::list<Module> modules_;
@@ -92,8 +95,12 @@ class VerilogParser
 {
 public:
     VerilogParser();
+    ~VerilogParser();
 
     Verilog *readStream(std::istream & in);
+private:
+    struct Impl;
+    std::unique_ptr<Impl> this_;
 };
 
 }

--- a/ophidian/parser/VerilogParser.h
+++ b/ophidian/parser/VerilogParser.h
@@ -1,6 +1,7 @@
 #ifndef VERILOGPARSER_H
 #define VERILOGPARSER_H
 
+#include <memory>
 #include <istream>
 #include <list>
 #include <map>

--- a/ophidian/parser/VerilogParser.h
+++ b/ophidian/parser/VerilogParser.h
@@ -1,0 +1,102 @@
+#ifndef VERILOGPARSER_H
+#define VERILOGPARSER_H
+
+#include <istream>
+#include <list>
+#include <map>
+
+namespace ophidian
+{
+namespace parser
+{
+
+class Verilog
+{
+public:
+    enum class PortDirection
+    {
+        INPUT,
+        OUTPUT,
+        INOUT
+    };
+
+    class Port
+    {
+    public:
+        Port(PortDirection direction, const std::string &name);
+        PortDirection direction() const;
+        const std::string &name() const;
+    private:
+        PortDirection direction_;
+        std::string name_;
+    };
+
+    class Net
+    {
+    public:
+        Net(const std::string & name);
+        const std::string& name() const;
+    private:
+        std::string name_;
+    };
+
+    class Module;
+    class Instance
+    {
+    public:
+        Instance(Module * module, const std::string name);
+        Module * module() const;
+        const std::string & name() const;
+        void mapPort(Port* port, Net * net);
+        const std::map<Port*, Net*> & portMapping() const;
+
+    private:
+        Module * module_;
+        std::string name_;
+        std::map<Port*, Net*> portMapping_;
+    };
+
+    class Module
+    {
+    public:
+        Module(const std::string& name);
+
+        Port *addPort(Verilog::PortDirection direction, const std::string name);
+        Net *addNet(const std::string & name);
+        Module *addModule(const std::string & name);
+        Instance *addInstance(Module * module, const std::string & name);
+
+        const std::string & name() const;
+        const std::list<Port> & ports() const;
+        const std::list<Net> & nets() const;
+        const std::list<Module> &modules() const;
+        const std::list<Instance> & instances() const;
+    private:
+        std::string name_;
+
+        std::list<Port> ports_;
+        std::list<Net> nets_;
+        std::list<Module> modules_;
+        std::list<Instance> instances_;
+    };
+
+
+    Module* addModule(const std::string & name);
+    const std::list<Module> & modules() const;
+
+private:
+    std::list<Module> modules_;
+};
+
+class VerilogParser
+{
+public:
+    VerilogParser();
+
+    Verilog *readStream(std::istream & in);
+};
+
+}
+}
+
+#endif // VERILOGPARSER_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,9 +7,10 @@ target_include_directories(Catch INTERFACE .)
 
 add_subdirectory(entity_system)
 add_subdirectory(circuit)
+add_subdirectory(parser)
 
 add_executable( run_tests ${SOURCE} ${HEADERS} )
-target_link_libraries(run_tests Catch ophidian_entitysystem ophidian_circuit verilogparser)
+target_link_libraries(run_tests Catch ophidian_entitysystem ophidian_circuit ophidian_parser)
 
 include_directories(${CMAKE_SOURCE_DIR})
 add_test(NAME unit_test COMMAND run_tests "~[Profiling]")

--- a/test/parser/CMakeLists.txt
+++ b/test/parser/CMakeLists.txt
@@ -1,0 +1,6 @@
+aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR} SRC_LIST)
+set(SOURCE
+   ${SOURCE}
+   ${SRC_LIST}
+   PARENT_SCOPE
+)

--- a/test/parser/verilog_test.cpp
+++ b/test/parser/verilog_test.cpp
@@ -1,0 +1,229 @@
+#include "verilog_test.h"
+#include <catch.hpp>
+
+#include <ophidian/parser/VerilogParser.h>
+
+#include <sstream>
+
+using namespace ophidian::parser;
+
+TEST_CASE("Verilog: add module", "[parser][VerilogParser]")
+{
+    Verilog file;
+    auto m = file.addModule("simple");
+    REQUIRE( file.modules().size() == 1 );
+    REQUIRE( std::count_if(file.modules().begin(), file.modules().end(), [m](const Verilog::Module & module)->bool{
+        return module.name() == m->name();
+    }) == 1 );
+    REQUIRE( m->name() == "simple" );
+}
+
+TEST_CASE("Verilog::Module: add port", "[parser][VerilogParser]")
+{
+    Verilog::Module simple("simple");
+    auto p = simple.addPort(Verilog::PortDirection::INPUT, "inp");
+    REQUIRE( simple.ports().size() == 1 );
+    REQUIRE( p->name() == "inp" );
+    REQUIRE( p->direction() == Verilog::PortDirection::INPUT );
+    REQUIRE( std::count_if(simple.ports().begin(), simple.ports().end(), [p](const Verilog::Port & port)->bool{
+        return p->name() == port.name() && p->direction() == port.direction();
+    }) == 1 );
+}
+
+TEST_CASE("Verilog::Module: add net", "[parser][VerilogParser]")
+{
+    Verilog::Module simple("simple");
+    auto n = simple.addNet("inp");
+    REQUIRE( simple.nets().size() == 1 );
+    REQUIRE( n->name() == "inp" );
+    REQUIRE( std::count_if(simple.nets().begin(), simple.nets().end(), [n](const Verilog::Net & net)->bool{
+        return n->name() == net.name();
+    }) == 1 );
+}
+
+TEST_CASE("Verilog::Module: add module", "[parser][VerilogParser]")
+{
+    Verilog::Module simple("simple");
+    auto submodule = simple.addModule("submodule");
+    REQUIRE( simple.modules().size() == 1 );
+    REQUIRE( submodule->name() == "submodule" );
+}
+
+TEST_CASE("Verilog::Module: add instance", "[parser][VerilogParser]")
+{
+    Verilog::Module simple("simple");
+    auto mod = simple.addModule("sub");
+    auto inst = simple.addInstance(mod, "u1");
+    REQUIRE( inst->module() == mod );
+    REQUIRE( inst->name() == "u1" );
+    REQUIRE( simple.instances().size() == 1 );
+}
+
+TEST_CASE("Verilog::Module: instance port mapping", "[parser][VerilogParser]")
+{
+    Verilog::Module simple("simple");
+    auto inpNet = simple.addNet("inpNet");
+    auto outNet = simple.addNet("outNet");
+
+    auto INV = simple.addModule("INV");
+    auto INVa = INV->addPort(Verilog::PortDirection::INPUT, "a");
+    auto INVo = INV->addPort(Verilog::PortDirection::OUTPUT, "o");
+
+    auto inst = simple.addInstance(INV, "u1");
+
+    inst->mapPort(INVa, inpNet);
+    inst->mapPort(INVo, outNet);
+
+    auto mapping = inst->portMapping();
+
+    REQUIRE( mapping[INVa] == inpNet );
+    REQUIRE( mapping[INVo] == outNet );
+    REQUIRE( mapping.size() == 2 );
+
+}
+
+TEST_CASE("VerilogParser: read from stream", "[parser][VerilogParser]")
+{
+    std::stringstream input("module simple(in, out); input in; output out; endmodule");
+    VerilogParser parser;
+    auto file = parser.readStream(input);
+}
+
+#include <iostream>
+TEST_CASE("Verilog::Module: simple test", "[parser][VerilogParser]")
+{
+    Verilog simpleVerilog;
+    auto design = simpleVerilog.addModule("design");
+    Verilog::Module *simple = design->addModule("simple");
+    auto topLevelInstance = design->addInstance(simple, "design");
+
+    auto inp1Port = simple->addPort(Verilog::PortDirection::INPUT, "inp1");
+    auto inp2Port = simple->addPort(Verilog::PortDirection::INPUT, "inp2");
+    auto clkPort = simple->addPort(Verilog::PortDirection::INPUT, "iccad_clk");
+    auto outPort = simple->addPort(Verilog::PortDirection::OUTPUT, "out");
+
+    auto NAND2 = simple->addModule("NAND2");
+    auto NAND2a = NAND2->addPort(Verilog::PortDirection::INPUT, "a");
+    auto NAND2b = NAND2->addPort(Verilog::PortDirection::INPUT, "b");
+    auto NAND2o = NAND2->addPort(Verilog::PortDirection::OUTPUT, "o");
+
+    auto NOR2 = simple->addModule("NOR2");
+    auto NOR2a = NOR2->addPort(Verilog::PortDirection::INPUT, "a");
+    auto NOR2b = NOR2->addPort(Verilog::PortDirection::INPUT, "b");
+    auto NOR2o = NOR2->addPort(Verilog::PortDirection::OUTPUT, "o");
+
+    auto INV = simple->addModule("INV");
+    auto INVa = INV->addPort(Verilog::PortDirection::INPUT, "a");
+    auto INVo = INV->addPort(Verilog::PortDirection::OUTPUT, "o");
+
+    auto DFF = simple->addModule("DFF");
+    auto DFFck = DFF->addPort(Verilog::PortDirection::INPUT, "ck");
+    auto DFFd = DFF->addPort(Verilog::PortDirection::INPUT, "d");
+    auto DFFq = DFF->addPort(Verilog::PortDirection::OUTPUT, "q");
+
+    auto inp1 = simple->addNet("inp1");
+    auto inp2 = simple->addNet("inp2");
+    auto out = simple->addNet("out");
+    auto iccad_clk = simple->addNet("iccad_clk");
+    auto n1 = simple->addNet("n1");
+    auto n2 = simple->addNet("n2");
+    auto n3 = simple->addNet("n3");
+    auto n4 = simple->addNet("n4");
+
+    Verilog::Instance *u1 = simple->addInstance(NAND2, "u1");
+    u1->mapPort(NAND2a, inp1);
+    u1->mapPort(NAND2b, inp2);
+    u1->mapPort(NAND2o, n1);
+
+    Verilog::Instance *u2 = simple->addInstance(NAND2, "u2");
+    u2->mapPort(NOR2a, n1);
+    u2->mapPort(NOR2b, n3);
+    u2->mapPort(NOR2o, n2);
+
+    Verilog::Instance *f1 = simple->addInstance(DFF, "f1");
+    f1->mapPort(DFFck, iccad_clk);
+    f1->mapPort(DFFd, n2);
+    f1->mapPort(DFFq, n3);
+
+    Verilog::Instance *u3 = simple->addInstance(INV, "u3");
+    u3->mapPort(INVa, n3);
+    u3->mapPort(INVo, n4);
+
+    Verilog::Instance *u4 = simple->addInstance(INV, "u4");
+    u4->mapPort(INVa, n4);
+    u4->mapPort(INVo, out);
+
+    REQUIRE( simpleVerilog.modules().size() == 1 );
+    REQUIRE( simple->instances().size() == 5 );
+    REQUIRE( simple->nets().size() == 8 );
+    REQUIRE( simple->ports().size() == 4 );
+
+    topLevelInstance->mapPort(inp1Port, inp1);
+    topLevelInstance->mapPort(inp2Port, inp2);
+    topLevelInstance->mapPort(clkPort, iccad_clk);
+    topLevelInstance->mapPort(outPort, out);
+
+    std::cout << "module " << topLevelInstance->module()->name() << "(";
+
+    std::size_t i = 0;
+    for(auto const & port : topLevelInstance->module()->ports())
+    {
+        std::cout << port.name();
+        if(++i == topLevelInstance->module()->ports().size())
+        {
+            std::cout << ");" << std::endl;
+        }
+        else
+        {
+            std::cout << ", ";
+        }
+    }
+
+    std::cout << "\n// Begin Ports" << std::endl;
+    for(auto const & port : topLevelInstance->portMapping())
+    {
+        std::string portTypeString;
+        switch(port.first->direction())
+        {
+        case Verilog::PortDirection::INPUT:
+            portTypeString = "input";
+            break;
+        case Verilog::PortDirection::OUTPUT:
+            portTypeString = "output";
+            break;
+        case Verilog::PortDirection::INOUT:
+            portTypeString = "inout";
+            break;
+        }
+        std::cout << portTypeString << " " << port.first->name() << ";" << std::endl;
+    }
+
+    std::cout << "\n// Begin Wires" << std::endl;
+    for(auto const & net : simple->nets())
+    {
+        std::cout << "wire " << net.name() << ";" << std::endl;
+    }
+
+    std::cout << "\n// Begin Cells" << std::endl;
+    for(auto const & instance : simple->instances())
+    {
+        std::cout << instance.module()->name() << " " << instance.name();
+        std::size_t i = 0;
+        for(auto const & port : instance.portMapping())
+        {
+            std::cout << " ." << port.first->name() << "( " << port.second->name() << " )";
+            if(++i == instance.portMapping().size())
+            {
+                std::cout << ";" << std::endl;
+            }
+            else
+            {
+                std::cout << ",";
+            }
+        }
+    }
+
+    std::cout << "endmodule" << std::endl;
+
+
+}

--- a/test/parser/verilog_test.h
+++ b/test/parser/verilog_test.h
@@ -1,0 +1,41 @@
+#ifndef OPHIDIAN_TEST_PARSER_VERILOG_TEST_H
+#define OPHIDIAN_TEST_PARSER_VERILOG_TEST_H
+
+#include <sstream>
+
+namespace test
+{
+
+const std::string simpleInput = "module simple (\n"
+                                "inp1,\n"
+                                "inp2,\n"
+                                "iccad_clk,\n"
+                                "out\n"
+                                ");\n"
+                                "// Start PIs\n"
+                                "input inp1;\n"
+                                "input inp2;\n"
+                                "input iccad_clk;\n"
+                                "// Start POs\n"
+                                "output out;\n"
+                                "// Start wires\n"
+                                "wire n1;\n"
+                                "wire n2;\n"
+                                "wire n3;\n"
+                                "wire n4;\n"
+                                "wire inp1;\n"
+                                "wire inp2;\n"
+                                "wire iccad_clk;\n"
+                                "wire out;\n"
+                                "wire lcb1_fo;\n"
+                                "// Start cells\n"
+                                "NAND2_X1 u1 ( .a(inp1), .b(inp2), .o(n1) );\n"
+                                "NOR2_X1 u2 ( .a(n1), .b(n3), .o(n2) );\n"
+                                "DFF_X80 f1 ( .d(n2), .ck(lcb1_fo), .q(n3) );\n"
+                                "INV_X1 u3 ( .a(n3), .o(n4) );\n"
+                                "INV_X1 u4 ( .a(n4), .o(out) );\n"
+                                "INV_Z80 lcb1 ( .a(iccad_clk), .o(lcb1_fo) );\n"
+                                "endmodule\n";
+}
+
+#endif


### PR DESCRIPTION
This adds Verilog parsing functionatilies.
This wraps the 3rdparty/verilog-parser with a more friendly interface.

A Verilog is a list of modules. A **module** may represent a logic gate or a more complex block. A module is composed of:
1. **Ports**: the interface of a module. A port has a name and a direction (INPUT, OUTPUT, INOUT, NONE).
2. **Nets**: extracted from `wire` statements or from module instantiations port connections.
2. **Instance**: instantiation of a module. If the module wasn't defined until its instantiation, it should be interpreted as an logic gate. The direction of Gate Instance Ports is unknown (=NONE) at this time.
