### PR TITLE
Geometry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-5
+            - libboost-all-dev
       env: COMPILER=g++-5
       
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,13 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-5
-            - libboost-all-dev
       env: COMPILER=g++-5
       
 before_script:
   - mkdir build && cd build
+  - wget https://sourceforge.net/projects/boost/files/boost/1.59.0/boost_1_59_0.tar.bz2/download
+  - tar jxf download
+  - sudo cp -r boost_1_59_0/boost /usr/include/
   - wget http://ftp.gnu.org/gnu/bison/bison-3.0.4.tar.gz
   - tar -zxvf bison-3.0.4.tar.gz
   - cd bison-3.0.4

--- a/ophidian/CMakeLists.txt
+++ b/ophidian/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(entity_system)
 add_subdirectory(circuit)
+add_subdirectory(geometry)
 

--- a/ophidian/geometry/CMakeLists.txt
+++ b/ophidian/geometry/CMakeLists.txt
@@ -1,0 +1,8 @@
+file(GLOB ophidian_geometry_SRC
+    "*.h"
+    "*.cpp"
+)
+add_library(ophidian_geometry ${ophidian_geometry_SRC})
+target_link_libraries(ophidian_geometry PUBLIC )
+install(TARGETS ophidian_geometry DESTINATION lib)
+install(FILES Distance.h Models.h Operations.h DESTINATION include/ophidian/geometry)

--- a/ophidian/geometry/Distance.cpp
+++ b/ophidian/geometry/Distance.cpp
@@ -1,0 +1,19 @@
+#include "Distance.h"
+
+namespace ophidian {
+namespace geometry {
+
+double ManhattanDistance::operator()(const Point &point1, const Point &point2) {
+  double distance = std::abs(point1.x() - point2.x()) + std::abs(point1.y() - point2.y());
+  return distance;
+}
+
+double EuclideanDistance::operator()(const Point & point1, const Point & point2) {
+  double distanceX = (point1.x() - point2.x()) * (point1.x() - point2.x());
+  double distanceY = (point1.y() - point2.y()) * (point1.y() - point2.y());
+  double distance = std::sqrt(distanceX + distanceY);
+  return distance;
+}
+
+}
+}

--- a/ophidian/geometry/Distance.h
+++ b/ophidian/geometry/Distance.h
@@ -6,16 +6,7 @@
 namespace ophidian {
 namespace geometry {
 
-class Distance {
-public:
-	Distance() {
-
-	}
-
-    virtual double operator()(const Point & point1, const Point & point2) = 0;
-};
-
-class ManhattanDistance : public Distance {
+class ManhattanDistance {
 public:
 	ManhattanDistance() {
 
@@ -24,7 +15,7 @@ public:
     double operator()(const Point & point1, const Point & point2);
 };
 
-class EuclideanDistance : public Distance {
+class EuclideanDistance {
 public:
 	EuclideanDistance() {
 

--- a/ophidian/geometry/Distance.h
+++ b/ophidian/geometry/Distance.h
@@ -1,0 +1,39 @@
+#ifndef OPHIDIAN_GEOMETRY_DISTANCE_H
+#define OPHIDIAN_GEOMETRY_DISTANCE_H
+
+#include "Models.h"
+
+namespace ophidian {
+namespace geometry {
+
+class Distance {
+public:
+	Distance() {
+
+	}
+
+    virtual double operator()(const Point & point1, const Point & point2) = 0;
+};
+
+class ManhattanDistance : public Distance {
+public:
+	ManhattanDistance() {
+
+	}
+
+    double operator()(const Point & point1, const Point & point2);
+};
+
+class EuclideanDistance : public Distance {
+public:
+	EuclideanDistance() {
+
+	}
+
+    double operator()(const Point &point1, const Point &point2);
+};
+
+}
+}
+
+#endif // OPHIDIAN_GEOMETRY_DISTANCE_H

--- a/ophidian/geometry/Distance.h
+++ b/ophidian/geometry/Distance.h
@@ -8,19 +8,41 @@ namespace geometry {
 
 class ManhattanDistance {
 public:
+    //! Construct ManhattanDistance
+    /*!
+     * \brief Empty default constructor
+     */
 	ManhattanDistance() {
 
 	}
 
+    //! Distance operator
+    /*!
+     * \brief Calculates the Manhattan distance between two points
+     * \param point1 First point to calculate the distance
+     * \param point2 Second point to calculate the distance
+     * \return Manhattan distance between point1 and point2
+     */
     double operator()(const Point & point1, const Point & point2);
 };
 
 class EuclideanDistance {
 public:
+    //! Construct EuclideanDistance
+    /*!
+     * \brief Empty default constructor
+     */
 	EuclideanDistance() {
 
 	}
 
+    //! Distance operator
+    /*!
+     * \brief Calculates the Euclidean distance between two points
+     * \param point1 First point to calculate the distance
+     * \param point2 Second point to calculate the distance
+     * \return Euclidean distance between point1 and point2
+     */
     double operator()(const Point &point1, const Point &point2);
 };
 

--- a/ophidian/geometry/Models.h
+++ b/ophidian/geometry/Models.h
@@ -1,0 +1,43 @@
+#ifndef OPHIDIAN_GEOMETRY_MODELS_H
+#define OPHIDIAN_GEOMETRY_MODELS_H
+
+#include <boost/geometry.hpp>
+#include <boost/geometry/geometries/point_xy.hpp>
+#include <boost/geometry/geometries/segment.hpp>
+#include <boost/geometry/geometries/linestring.hpp>
+#include <boost/geometry/geometries/box.hpp>
+#include <boost/geometry/geometries/polygon.hpp>
+#include <boost/geometry/geometries/multi_polygon.hpp>
+
+namespace ophidian {
+namespace geometry {
+
+using Point = boost::geometry::model::d2::point_xy<double>;
+using Segment = boost::geometry::model::segment<Point>;
+using Linestring = boost::geometry::model::linestring<Point>;
+using Box = boost::geometry::model::box<Point>;
+using Polygon = boost::geometry::model::polygon<Point>;
+using MultiPolygon = boost::geometry::model::multi_polygon<Polygon>;
+
+template<class Geometry>
+Geometry make(const std::vector<Point> & points) {
+    Geometry geometry;
+    for (auto point : points) {
+        boost::geometry::append(geometry, point);
+    }
+    return geometry;
+}
+
+template<class MultiGeometry, class PartGeometry>
+MultiGeometry makeMulti(const std::vector<PartGeometry> & parts) {
+    MultiGeometry multiGeometry;
+    for (auto part : parts) {
+        multiGeometry.push_back(part);
+    }
+    return multiGeometry;
+}
+
+}
+}
+
+#endif // OPHIDIAN_GEOMETRY_MODELS_H

--- a/ophidian/geometry/Models.h
+++ b/ophidian/geometry/Models.h
@@ -19,6 +19,12 @@ using Box = boost::geometry::model::box<Point>;
 using Polygon = boost::geometry::model::polygon<Point>;
 using MultiPolygon = boost::geometry::model::multi_polygon<Polygon>;
 
+//! Create new geometry
+/*!
+ *  \brief Creates a new geometry from a vector of points. Can be used for Linestring and Polygon. Should not be used for Segment and Box.
+ * \param points Vector of points of the geometry
+ * \return The created geometry
+ */
 template<class Geometry>
 Geometry make(const std::vector<Point> & points) {
     Geometry geometry;
@@ -28,6 +34,12 @@ Geometry make(const std::vector<Point> & points) {
     return geometry;
 }
 
+//! Create new multi geometry
+/*!
+ *  \brief Creates a new multi geometry from a vector of points. Can be used for MultiPolygon, but could be extended for other multi geometries, such as a MultiBox.
+ * \param parts The geometries of the multi geometry
+ * \return The created multi geometry
+ */
 template<class MultiGeometry, class PartGeometry>
 MultiGeometry makeMulti(const std::vector<PartGeometry> & parts) {
     MultiGeometry multiGeometry;

--- a/ophidian/geometry/Operations.h
+++ b/ophidian/geometry/Operations.h
@@ -16,18 +16,18 @@ void translate(const Geometry & geometry, const Point & translationPoint, Geomet
 
 template<class Geometry>
 void scale(const Geometry & geometry, const Point & scalePoint, Geometry & result) {
-	boost::geometry::strategy::transform::scale_transformer<double, 2, 2> scale(scalePoint.x(), scalePoint.y());
-	boost::geometry::transform(geometry, result, scale);
+    boost::geometry::strategy::transform::scale_transformer<double, 2, 2> scale(scalePoint.x(), scalePoint.y());
+    boost::geometry::transform(geometry, result, scale);
 }
 
 template<class Geometry>
-void rotate(const Geometry & geometry, boost::geometry::degree degree, Geometry & result) {
+void rotate(const Geometry & geometry, double degree, Geometry & result) {
 	boost::geometry::strategy::transform::rotate_transformer<boost::geometry::degree, double, 2, 2> rotate(degree);
 	boost::geometry::transform(geometry, result, rotate);
 }
 
-template<class Geometry>
-void intersection(const Geometry & geometry1, const Geometry & geometry2, Geometry & result) {
+template<class Geometry1, class Geometry2, class GeometryOut>
+void intersection(const Geometry1 & geometry1, const Geometry2 & geometry2, GeometryOut & result) {
     boost::geometry::intersection(geometry1, geometry2, result);
 }
 

--- a/ophidian/geometry/Operations.h
+++ b/ophidian/geometry/Operations.h
@@ -1,0 +1,37 @@
+#ifndef OPHIDIAN_GEOMETRY_OPERATIONS_H
+#define OPHIDIAN_GEOMETRY_OPERATIONS_H
+
+#include <boost/geometry/algorithms/intersection.hpp>
+
+#include "Models.h"
+
+namespace ophidian {
+namespace geometry {
+
+template<class Geometry>
+void translate(const Geometry & geometry, const Point & translationPoint, Geometry & result) {
+	boost::geometry::strategy::transform::translate_transformer<double, 2, 2> translate(translationPoint.x(), translationPoint.y());
+	boost::geometry::transform(geometry, result, translate);
+}
+
+template<class Geometry>
+void scale(const Geometry & geometry, const Point & scalePoint, Geometry & result) {
+	boost::geometry::strategy::transform::scale_transformer<double, 2, 2> scale(scalePoint.x(), scalePoint.y());
+	boost::geometry::transform(geometry, result, scale);
+}
+
+template<class Geometry>
+void rotate(const Geometry & geometry, boost::geometry::degree degree, Geometry & result) {
+	boost::geometry::strategy::transform::rotate_transformer<boost::geometry::degree, double, 2, 2> rotate(degree);
+	boost::geometry::transform(geometry, result, rotate);
+}
+
+template<class Geometry>
+void intersection(const Geometry & geometry1, const Geometry & geometry2, Geometry & result) {
+    boost::geometry::intersection(geometry1, geometry2, result);
+}
+
+}
+}
+
+#endif // OPHIDIAN_GEOMETRY_OPERATIONS_H

--- a/ophidian/geometry/Operations.h
+++ b/ophidian/geometry/Operations.h
@@ -8,24 +8,52 @@
 namespace ophidian {
 namespace geometry {
 
+//! Translation operation
+/*!
+ * \brief Translates a geometry by a given point
+ * \param geometry Geometry to be translated
+ * \param translationPoint Point representing the translation to be applied to geometry
+ * \param result Geometry representing the translated geometry
+ */
 template<class Geometry>
 void translate(const Geometry & geometry, const Point & translationPoint, Geometry & result) {
 	boost::geometry::strategy::transform::translate_transformer<double, 2, 2> translate(translationPoint.x(), translationPoint.y());
 	boost::geometry::transform(geometry, result, translate);
 }
 
+//! Scaling operation
+/*!
+ * \brief Scales a geometry by a given point
+ * \param geometry Geometry to be scaled
+ * \param scalingPoint Point representing the scaling to be applied to geometry
+ * \param result Geometry representing the scaled geometry
+ */
 template<class Geometry>
-void scale(const Geometry & geometry, const Point & scalePoint, Geometry & result) {
-    boost::geometry::strategy::transform::scale_transformer<double, 2, 2> scale(scalePoint.x(), scalePoint.y());
+void scale(const Geometry & geometry, const Point & scalingPoint, Geometry & result) {
+    boost::geometry::strategy::transform::scale_transformer<double, 2, 2> scale(scalingPoint.x(), scalingPoint.y());
     boost::geometry::transform(geometry, result, scale);
 }
 
+//! Rotate operation
+/*!
+ * \brief Rotates a geometry by a given amount of degrees
+ * \param geometry Geometry to be rotated
+ * \param degree Amount of rotation degrees
+ * \param result Geometry representing the rotated geometry
+ */
 template<class Geometry>
 void rotate(const Geometry & geometry, double degree, Geometry & result) {
 	boost::geometry::strategy::transform::rotate_transformer<boost::geometry::degree, double, 2, 2> rotate(degree);
 	boost::geometry::transform(geometry, result, rotate);
 }
 
+//! Intersection operation
+/*!
+ * \brief Calculates the intersection between two geometries
+ * \param geometry1 First geometry to calculate the intersection
+ * \param geometry2 Second geometry to calculate the intersection
+ * \param result Geometry representing the intersection of geometry1 and geometry2. Should be a collection of geometries, a multi geometry or a Box in the case of Box intersection
+ */
 template<class Geometry1, class Geometry2, class GeometryOut>
 void intersection(const Geometry1 & geometry1, const Geometry2 & geometry2, GeometryOut & result) {
     boost::geometry::intersection(geometry1, geometry2, result);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,7 +11,7 @@ add_subdirectory(geometry)
 add_subdirectory(parser)
 
 add_executable( run_tests ${SOURCE} ${HEADERS} )
-target_link_libraries(run_tests Catch ophidian_entitysystem ophidian_circuit verilogparser geometry parser)
+target_link_libraries(run_tests Catch ophidian_entitysystem ophidian_circuit verilogparser ophidian_geometry ophidian_parser)
 
 include_directories(${CMAKE_SOURCE_DIR})
 add_test(NAME unit_test COMMAND run_tests "~[Profiling]")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,9 +7,10 @@ target_include_directories(Catch INTERFACE .)
 
 add_subdirectory(entity_system)
 add_subdirectory(circuit)
+add_subdirectory(geometry)
 
 add_executable( run_tests ${SOURCE} ${HEADERS} )
-target_link_libraries(run_tests Catch ophidian_entitysystem ophidian_circuit verilogparser)
+target_link_libraries(run_tests Catch ophidian_entitysystem ophidian_circuit verilogparser ophidian_geometry)
 
 include_directories(${CMAKE_SOURCE_DIR})
 add_test(NAME unit_test COMMAND run_tests "~[Profiling]")

--- a/test/geometry/CMakeLists.txt
+++ b/test/geometry/CMakeLists.txt
@@ -1,0 +1,6 @@
+aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR} SRC_LIST)
+set(SOURCE
+   ${SOURCE}
+   ${SRC_LIST}
+   PARENT_SCOPE
+)

--- a/test/geometry/distance_test.cpp
+++ b/test/geometry/distance_test.cpp
@@ -1,0 +1,23 @@
+#include <catch.hpp>
+
+#include <ophidian/geometry/Distance.h>
+
+using namespace ophidian::geometry;
+
+TEST_CASE("Geometry: manhattan distance between two points", "[geometry][distance]") {
+    Point point1(5, 10);
+    Point point2(3, 7);
+    ManhattanDistance manhattanDistance;
+    double distance = manhattanDistance(point1, point2);
+    double expected_distance = 5;
+    REQUIRE(distance == Approx(expected_distance));
+}
+
+TEST_CASE("Geometry: euclidean distance between two points", "[geometry][distance]") {
+    Point point1(5, 10);
+    Point point2(3, 7);
+    EuclideanDistance euclideanDistance;
+    double distance = euclideanDistance(point1, point2);
+    double expected_distance = std::sqrt(13);
+    REQUIRE(distance == Approx(expected_distance));
+}

--- a/test/geometry/intersectiontest.cpp
+++ b/test/geometry/intersectiontest.cpp
@@ -1,0 +1,56 @@
+#include <catch.hpp>
+
+#include <ophidian/geometry/Operations.h>
+
+using namespace ophidian::geometry;
+
+TEST_CASE("Geometry: intersection between two boxes", "[geometry][operations]") {
+    Box box1(Point(1.0, 1.0), Point(3.0, 3.0));
+    Box box2(Point(2.0, 1.0), Point(4.0, 3.0));
+
+    Box intersectionBox;
+    intersection(box1, box2, intersectionBox);
+
+    REQUIRE(intersectionBox.min_corner().x() == Approx(2.0));
+    REQUIRE(intersectionBox.min_corner().y() == Approx(1.0));
+    REQUIRE(intersectionBox.max_corner().x() == Approx(3.0));
+    REQUIRE(intersectionBox.max_corner().y() == Approx(3.0));
+}
+
+TEST_CASE("Geometry: intersection between two polygons", "[geometry][operations]") {
+    std::vector<Point> points1 = {
+        Point(1.0, 1.0),
+        Point(1.0, 3.0),
+        Point(3.0, 3.0),
+        Point(3.0, 1.0),
+        Point(1.0, 1.0),
+    };
+    Polygon polygon1 = make<Polygon>(points1);
+
+    std::vector<Point> points2 = {
+        Point(2.0, 1.0),
+        Point(2.0, 3.0),
+        Point(4.0, 3.0),
+        Point(4.0, 1.0),
+        Point(2.0, 1.0),
+    };
+    Polygon polygon2 = make<Polygon>(points2);
+
+    MultiPolygon intersection;
+    //intersection(polygon1, polygon2, intersection);
+    boost::geometry::intersection(polygon1, polygon2, intersection);
+
+    REQUIRE(intersection.size() == 1);
+
+    std::vector<Point> intersectionPoints(intersection.at(0).outer().begin(), intersection.at(0).outer().end());
+    REQUIRE(intersectionPoints.at(0).x() == Approx(2.0));
+    REQUIRE(intersectionPoints.at(0).y() == Approx(3.0));
+    REQUIRE(intersectionPoints.at(1).x() == Approx(3.0));
+    REQUIRE(intersectionPoints.at(1).y() == Approx(3.0));
+    REQUIRE(intersectionPoints.at(2).x() == Approx(3.0));
+    REQUIRE(intersectionPoints.at(2).y() == Approx(1.0));
+    REQUIRE(intersectionPoints.at(3).x() == Approx(2.0));
+    REQUIRE(intersectionPoints.at(3).y() == Approx(1.0));
+    REQUIRE(intersectionPoints.at(4).x() == Approx(2.0));
+    REQUIRE(intersectionPoints.at(4).y() == Approx(3.0));
+}

--- a/test/geometry/intersectiontest.cpp
+++ b/test/geometry/intersectiontest.cpp
@@ -36,13 +36,12 @@ TEST_CASE("Geometry: intersection between two polygons", "[geometry][operations]
     };
     Polygon polygon2 = make<Polygon>(points2);
 
-    MultiPolygon intersection;
-    //intersection(polygon1, polygon2, intersection);
-    boost::geometry::intersection(polygon1, polygon2, intersection);
+    MultiPolygon intersectionResult;
+    intersection(polygon1, polygon2, intersectionResult);
 
-    REQUIRE(intersection.size() == 1);
+    REQUIRE(intersectionResult.size() == 1);
 
-    std::vector<Point> intersectionPoints(intersection.at(0).outer().begin(), intersection.at(0).outer().end());
+    std::vector<Point> intersectionPoints(intersectionResult.at(0).outer().begin(), intersectionResult.at(0).outer().end());
     REQUIRE(intersectionPoints.at(0).x() == Approx(2.0));
     REQUIRE(intersectionPoints.at(0).y() == Approx(3.0));
     REQUIRE(intersectionPoints.at(1).x() == Approx(3.0));

--- a/test/geometry/models_test.cpp
+++ b/test/geometry/models_test.cpp
@@ -2,162 +2,92 @@
 
 #include <ophidian/geometry/Models.h>
 
+#include "modelsfixture.h"
+
 using namespace ophidian::geometry;
 
-TEST_CASE("Geometry: new Point must have correct coordinate values", "[geometry][models]") {
-    double x = 1.0;
-    double y = 2.0;
-    Point point(x, y);
-    REQUIRE(point.x() == x);
-    REQUIRE(point.y() == y);
+TEST_CASE("Geometry: creating new Point", "[geometry][models]") {
+    PointFixture pointFixture;
+    Point point = pointFixture.point;
+    REQUIRE(point.x() == pointFixture.x);
+    REQUIRE(point.y() == pointFixture.y);
 }
 
-TEST_CASE("Geometry: new Segment must have correct coordinate values", "[geometry][models]") {
-    double x1 = 1.0;
-    double y1 = 2.0;
-    double x2 = 2.0;
-    double y2 = 1.0;
-    Point segmentBegin(x1, y1);
-    Point segmentEnd(x2, y2);
-    Segment segment(segmentBegin, segmentEnd);
-    REQUIRE(segment.first.x() == x1);
-    REQUIRE(segment.first.y() == y1);
-    REQUIRE(segment.second.x() == x2);
-    REQUIRE(segment.second.y() == y2);
+TEST_CASE("Geometry: creating new Segment", "[geometry][models]") {
+    SegmentFixture segmentFixture;
+    Segment segment = segmentFixture.segment;
+    REQUIRE(segment.first.x() == segmentFixture.x1);
+    REQUIRE(segment.first.y() == segmentFixture.y1);
+    REQUIRE(segment.second.x() == segmentFixture.x2);
+    REQUIRE(segment.second.y() == segmentFixture.y2);
 }
 
-TEST_CASE("Geometry: new Linestring must have correct coordinate values", "[geometry][models]") {
-    double x1 = 1.0;
-    double y1 = 2.0;
-    double x2 = 2.0;
-    double y2 = 1.0;
-    double x3 = 2.0;
-    double y3 = 1.0;
-    std::vector<Point> points = {
-        Point(x1, y1),
-        Point(x2, y2),
-        Point(x3, y3),
-    };
-    Linestring linestring(points.begin(), points.end());
+TEST_CASE("Geometry: creating new Linestring", "[geometry][models]") {
+    LinestringFixture linestringFixture;
+    Linestring linestring = linestringFixture.linestring;
     std::vector<Point> linestringPoints(linestring.begin(), linestring.end());
     REQUIRE(linestringPoints.size() == 3);
-    REQUIRE(linestringPoints.at(0).x() == x1);
-    REQUIRE(linestringPoints.at(0).y() == y1);
-    REQUIRE(linestringPoints.at(1).x() == x2);
-    REQUIRE(linestringPoints.at(1).y() == y2);
-    REQUIRE(linestringPoints.at(2).x() == x3);
-    REQUIRE(linestringPoints.at(2).y() == y3);
+    REQUIRE(linestringPoints.at(0).x() == linestringFixture.x1);
+    REQUIRE(linestringPoints.at(0).y() == linestringFixture.y1);
+    REQUIRE(linestringPoints.at(1).x() == linestringFixture.x2);
+    REQUIRE(linestringPoints.at(1).y() == linestringFixture.y2);
+    REQUIRE(linestringPoints.at(2).x() == linestringFixture.x3);
+    REQUIRE(linestringPoints.at(2).y() == linestringFixture.y3);
 }
 
-TEST_CASE("Geometry: new Box must have correct coordinate values", "[geometry][models]") {
-    double xMin = 1.0;
-    double yMin = 2.0;
-    double xMax = 2.0;
-    double yMax = 2.0;
-    Point minCorner(xMin, yMin);
-    Point maxCorner(xMax, yMax);
-    Box box(minCorner, maxCorner);
-    REQUIRE(box.min_corner().x() == xMin);
-    REQUIRE(box.min_corner().y() == yMin);
-    REQUIRE(box.max_corner().x() == xMax);
-    REQUIRE(box.max_corner().y() == yMax);
+TEST_CASE("Geometry: creating new Box", "[geometry][models]") {
+    BoxFixture boxFixture;
+    Box box = boxFixture.box;
+    REQUIRE(box.min_corner().x() == boxFixture.xMin);
+    REQUIRE(box.min_corner().y() == boxFixture.yMin);
+    REQUIRE(box.max_corner().x() == boxFixture.xMax);
+    REQUIRE(box.max_corner().y() == boxFixture.yMax);
 }
 
-TEST_CASE("Geometry: new Polygon must have correct coordinate values", "[geometry][models]") {
-    double x1 = 1.0;
-    double y1 = 1.0;
-    double x2 = 2.0;
-    double y2 = 1.0;
-    double x3 = 2.0;
-    double y3 = 2.0;
-    double x4 = 1.0;
-    double y4 = 2.0;
-    std::vector<Point> points = {
-        Point(x1, y1),
-        Point(x2, y2),
-        Point(x3, y3),
-        Point(x4, y4),
-        Point(x1, y1),
-    };
-    Polygon polygon = make<Polygon>(points);
+TEST_CASE("Geometry: creating new Polygon", "[geometry][models]") {
+    PolygonFixture polygonFixture;
+    Polygon polygon = polygonFixture.polygon;
     std::vector<Point> polygonPoints(polygon.outer().begin(), polygon.outer().end());
     REQUIRE(polygonPoints.size() == 5);
-    REQUIRE(polygonPoints.at(0).x() == x1);
-    REQUIRE(polygonPoints.at(0).y() == y1);
-    REQUIRE(polygonPoints.at(1).x() == x2);
-    REQUIRE(polygonPoints.at(1).y() == y2);
-    REQUIRE(polygonPoints.at(2).x() == x3);
-    REQUIRE(polygonPoints.at(2).y() == y3);
-    REQUIRE(polygonPoints.at(3).x() == x4);
-    REQUIRE(polygonPoints.at(3).y() == y4);
-    REQUIRE(polygonPoints.at(4).x() == x1);
-    REQUIRE(polygonPoints.at(4).y() == y1);
+    REQUIRE(polygonPoints.at(0).x() == polygonFixture.x1);
+    REQUIRE(polygonPoints.at(0).y() == polygonFixture.y1);
+    REQUIRE(polygonPoints.at(1).x() == polygonFixture.x2);
+    REQUIRE(polygonPoints.at(1).y() == polygonFixture.y2);
+    REQUIRE(polygonPoints.at(2).x() == polygonFixture.x3);
+    REQUIRE(polygonPoints.at(2).y() == polygonFixture.y3);
+    REQUIRE(polygonPoints.at(3).x() == polygonFixture.x4);
+    REQUIRE(polygonPoints.at(3).y() == polygonFixture.y4);
+    REQUIRE(polygonPoints.at(4).x() == polygonFixture.x1);
+    REQUIRE(polygonPoints.at(4).y() == polygonFixture.y1);
 }
 
-TEST_CASE("Geometry: new MultiPolygon must have correct coordinate values", "[geometry][models]") {
-    double x1 = 1.0;
-    double y1 = 1.0;
-    double x2 = 2.0;
-    double y2 = 1.0;
-    double x3 = 2.0;
-    double y3 = 2.0;
-    double x4 = 1.0;
-    double y4 = 2.0;
-    std::vector<Point> points1 = {
-        Point(x1, y1),
-        Point(x2, y2),
-        Point(x3, y3),
-        Point(x4, y4),
-        Point(x1, y1),
-    };
-    Polygon polygon1 = make<Polygon>(points1);
-
-    double x5 = 1.0;
-    double y5 = 1.0;
-    double x6 = 2.0;
-    double y6 = 1.0;
-    double x7 = 2.0;
-    double y7 = 2.0;
-    double x8 = 1.0;
-    double y8 = 2.0;
-    std::vector<Point> points2 = {
-        Point(x5, y5),
-        Point(x6, y6),
-        Point(x7, y7),
-        Point(x8, y8),
-        Point(x5, y5),
-    };
-    Polygon polygon2 = make<Polygon>(points2);
-
-    std::vector<Polygon> polygons = {
-        polygon1,
-        polygon2
-    };
-    MultiPolygon multiPolygon = makeMulti<MultiPolygon>(polygons);
+TEST_CASE("Geometry: creating new MultiPolygon", "[geometry][models]") {
+    MultiPolygonFixture multiPolygonFixture;
+    MultiPolygon multiPolygon = multiPolygonFixture.multiPolygon;
 
     std::vector<Point> polygon1Points(multiPolygon.at(0).outer().begin(), multiPolygon.at(0).outer().end());
     REQUIRE(polygon1Points.size() == 5);
-    REQUIRE(polygon1Points.at(0).x() == x1);
-    REQUIRE(polygon1Points.at(0).y() == y1);
-    REQUIRE(polygon1Points.at(1).x() == x2);
-    REQUIRE(polygon1Points.at(1).y() == y2);
-    REQUIRE(polygon1Points.at(2).x() == x3);
-    REQUIRE(polygon1Points.at(2).y() == y3);
-    REQUIRE(polygon1Points.at(3).x() == x4);
-    REQUIRE(polygon1Points.at(3).y() == y4);
-    REQUIRE(polygon1Points.at(4).x() == x1);
-    REQUIRE(polygon1Points.at(4).y() == y1);
+    REQUIRE(polygon1Points.at(0).x() == multiPolygonFixture.x1);
+    REQUIRE(polygon1Points.at(0).y() == multiPolygonFixture.y1);
+    REQUIRE(polygon1Points.at(1).x() == multiPolygonFixture.x2);
+    REQUIRE(polygon1Points.at(1).y() == multiPolygonFixture.y2);
+    REQUIRE(polygon1Points.at(2).x() == multiPolygonFixture.x3);
+    REQUIRE(polygon1Points.at(2).y() == multiPolygonFixture.y3);
+    REQUIRE(polygon1Points.at(3).x() == multiPolygonFixture.x4);
+    REQUIRE(polygon1Points.at(3).y() == multiPolygonFixture.y4);
+    REQUIRE(polygon1Points.at(4).x() == multiPolygonFixture.x1);
+    REQUIRE(polygon1Points.at(4).y() == multiPolygonFixture.y1);
 
     std::vector<Point> polygon2Points(multiPolygon.at(1).outer().begin(), multiPolygon.at(1).outer().end());
     REQUIRE(polygon2Points.size() == 5);
-    REQUIRE(polygon2Points.at(0).x() == x5);
-    REQUIRE(polygon2Points.at(0).y() == y5);
-    REQUIRE(polygon2Points.at(1).x() == x6);
-    REQUIRE(polygon2Points.at(1).y() == y6);
-    REQUIRE(polygon2Points.at(2).x() == x7);
-    REQUIRE(polygon2Points.at(2).y() == y7);
-    REQUIRE(polygon2Points.at(3).x() == x8);
-    REQUIRE(polygon2Points.at(3).y() == y8);
-    REQUIRE(polygon2Points.at(4).x() == x5);
-    REQUIRE(polygon2Points.at(4).y() == y5);
+    REQUIRE(polygon2Points.at(0).x() == multiPolygonFixture.x5);
+    REQUIRE(polygon2Points.at(0).y() == multiPolygonFixture.y5);
+    REQUIRE(polygon2Points.at(1).x() == multiPolygonFixture.x6);
+    REQUIRE(polygon2Points.at(1).y() == multiPolygonFixture.y6);
+    REQUIRE(polygon2Points.at(2).x() == multiPolygonFixture.x7);
+    REQUIRE(polygon2Points.at(2).y() == multiPolygonFixture.y7);
+    REQUIRE(polygon2Points.at(3).x() == multiPolygonFixture.x8);
+    REQUIRE(polygon2Points.at(3).y() == multiPolygonFixture.y8);
+    REQUIRE(polygon2Points.at(4).x() == multiPolygonFixture.x5);
+    REQUIRE(polygon2Points.at(4).y() == multiPolygonFixture.y5);
 }

--- a/test/geometry/models_test.cpp
+++ b/test/geometry/models_test.cpp
@@ -1,0 +1,163 @@
+#include <catch.hpp>
+
+#include <ophidian/geometry/Models.h>
+
+using namespace ophidian::geometry;
+
+TEST_CASE("Geometry: new Point must have correct coordinate values", "[geometry][models]") {
+    double x = 1.0;
+    double y = 2.0;
+    Point point(x, y);
+    REQUIRE(point.x() == x);
+    REQUIRE(point.y() == y);
+}
+
+TEST_CASE("Geometry: new Segment must have correct coordinate values", "[geometry][models]") {
+    double x1 = 1.0;
+    double y1 = 2.0;
+    double x2 = 2.0;
+    double y2 = 1.0;
+    Point segmentBegin(x1, y1);
+    Point segmentEnd(x2, y2);
+    Segment segment(segmentBegin, segmentEnd);
+    REQUIRE(segment.first.x() == x1);
+    REQUIRE(segment.first.y() == y1);
+    REQUIRE(segment.second.x() == x2);
+    REQUIRE(segment.second.y() == y2);
+}
+
+TEST_CASE("Geometry: new Linestring must have correct coordinate values", "[geometry][models]") {
+    double x1 = 1.0;
+    double y1 = 2.0;
+    double x2 = 2.0;
+    double y2 = 1.0;
+    double x3 = 2.0;
+    double y3 = 1.0;
+    std::vector<Point> points = {
+        Point(x1, y1),
+        Point(x2, y2),
+        Point(x3, y3),
+    };
+    Linestring linestring(points.begin(), points.end());
+    std::vector<Point> linestringPoints(linestring.begin(), linestring.end());
+    REQUIRE(linestringPoints.size() == 3);
+    REQUIRE(linestringPoints.at(0).x() == x1);
+    REQUIRE(linestringPoints.at(0).y() == y1);
+    REQUIRE(linestringPoints.at(1).x() == x2);
+    REQUIRE(linestringPoints.at(1).y() == y2);
+    REQUIRE(linestringPoints.at(2).x() == x3);
+    REQUIRE(linestringPoints.at(2).y() == y3);
+}
+
+TEST_CASE("Geometry: new Box must have correct coordinate values", "[geometry][models]") {
+    double xMin = 1.0;
+    double yMin = 2.0;
+    double xMax = 2.0;
+    double yMax = 2.0;
+    Point minCorner(xMin, yMin);
+    Point maxCorner(xMax, yMax);
+    Box box(minCorner, maxCorner);
+    REQUIRE(box.min_corner().x() == xMin);
+    REQUIRE(box.min_corner().y() == yMin);
+    REQUIRE(box.max_corner().x() == xMax);
+    REQUIRE(box.max_corner().y() == yMax);
+}
+
+TEST_CASE("Geometry: new Polygon must have correct coordinate values", "[geometry][models]") {
+    double x1 = 1.0;
+    double y1 = 1.0;
+    double x2 = 2.0;
+    double y2 = 1.0;
+    double x3 = 2.0;
+    double y3 = 2.0;
+    double x4 = 1.0;
+    double y4 = 2.0;
+    std::vector<Point> points = {
+        Point(x1, y1),
+        Point(x2, y2),
+        Point(x3, y3),
+        Point(x4, y4),
+        Point(x1, y1),
+    };
+    Polygon polygon = make<Polygon>(points);
+    std::vector<Point> polygonPoints(polygon.outer().begin(), polygon.outer().end());
+    REQUIRE(polygonPoints.size() == 5);
+    REQUIRE(polygonPoints.at(0).x() == x1);
+    REQUIRE(polygonPoints.at(0).y() == y1);
+    REQUIRE(polygonPoints.at(1).x() == x2);
+    REQUIRE(polygonPoints.at(1).y() == y2);
+    REQUIRE(polygonPoints.at(2).x() == x3);
+    REQUIRE(polygonPoints.at(2).y() == y3);
+    REQUIRE(polygonPoints.at(3).x() == x4);
+    REQUIRE(polygonPoints.at(3).y() == y4);
+    REQUIRE(polygonPoints.at(4).x() == x1);
+    REQUIRE(polygonPoints.at(4).y() == y1);
+}
+
+TEST_CASE("Geometry: new MultiPolygon must have correct coordinate values", "[geometry][models]") {
+    double x1 = 1.0;
+    double y1 = 1.0;
+    double x2 = 2.0;
+    double y2 = 1.0;
+    double x3 = 2.0;
+    double y3 = 2.0;
+    double x4 = 1.0;
+    double y4 = 2.0;
+    std::vector<Point> points1 = {
+        Point(x1, y1),
+        Point(x2, y2),
+        Point(x3, y3),
+        Point(x4, y4),
+        Point(x1, y1),
+    };
+    Polygon polygon1 = make<Polygon>(points1);
+
+    double x5 = 1.0;
+    double y5 = 1.0;
+    double x6 = 2.0;
+    double y6 = 1.0;
+    double x7 = 2.0;
+    double y7 = 2.0;
+    double x8 = 1.0;
+    double y8 = 2.0;
+    std::vector<Point> points2 = {
+        Point(x5, y5),
+        Point(x6, y6),
+        Point(x7, y7),
+        Point(x8, y8),
+        Point(x5, y5),
+    };
+    Polygon polygon2 = make<Polygon>(points2);
+
+    std::vector<Polygon> polygons = {
+        polygon1,
+        polygon2
+    };
+    MultiPolygon multiPolygon = makeMulti<MultiPolygon>(polygons);
+
+    std::vector<Point> polygon1Points(multiPolygon.at(0).outer().begin(), multiPolygon.at(0).outer().end());
+    REQUIRE(polygon1Points.size() == 5);
+    REQUIRE(polygon1Points.at(0).x() == x1);
+    REQUIRE(polygon1Points.at(0).y() == y1);
+    REQUIRE(polygon1Points.at(1).x() == x2);
+    REQUIRE(polygon1Points.at(1).y() == y2);
+    REQUIRE(polygon1Points.at(2).x() == x3);
+    REQUIRE(polygon1Points.at(2).y() == y3);
+    REQUIRE(polygon1Points.at(3).x() == x4);
+    REQUIRE(polygon1Points.at(3).y() == y4);
+    REQUIRE(polygon1Points.at(4).x() == x1);
+    REQUIRE(polygon1Points.at(4).y() == y1);
+
+    std::vector<Point> polygon2Points(multiPolygon.at(1).outer().begin(), multiPolygon.at(1).outer().end());
+    REQUIRE(polygon2Points.size() == 5);
+    REQUIRE(polygon2Points.at(0).x() == x5);
+    REQUIRE(polygon2Points.at(0).y() == y5);
+    REQUIRE(polygon2Points.at(1).x() == x6);
+    REQUIRE(polygon2Points.at(1).y() == y6);
+    REQUIRE(polygon2Points.at(2).x() == x7);
+    REQUIRE(polygon2Points.at(2).y() == y7);
+    REQUIRE(polygon2Points.at(3).x() == x8);
+    REQUIRE(polygon2Points.at(3).y() == y8);
+    REQUIRE(polygon2Points.at(4).x() == x5);
+    REQUIRE(polygon2Points.at(4).y() == y5);
+}

--- a/test/geometry/modelsfixture.cpp
+++ b/test/geometry/modelsfixture.cpp
@@ -1,0 +1,68 @@
+#include "modelsfixture.h"
+
+using namespace ophidian::geometry;
+
+PointFixture::PointFixture()
+    : point(x, y){
+
+}
+
+SegmentFixture::SegmentFixture() {
+    Point segmentBegin(x1, y1);
+    Point segmentEnd(x2, y2);
+    segment = Segment(segmentBegin, segmentEnd);
+}
+
+LinestringFixture::LinestringFixture()
+{
+    std::vector<Point> points = {
+        Point(x1, y1),
+        Point(x2, y2),
+        Point(x3, y3),
+    };
+    linestring = make<Linestring>(points);
+}
+
+BoxFixture::BoxFixture()
+{
+    box = Box(Point(xMin, yMin), Point(xMax, yMax));
+}
+
+PolygonFixture::PolygonFixture()
+{
+    std::vector<Point> points = {
+        Point(x1, y1),
+        Point(x2, y2),
+        Point(x3, y3),
+        Point(x4, y4),
+        Point(x1, y1),
+    };
+    polygon = make<Polygon>(points);
+}
+
+MultiPolygonFixture::MultiPolygonFixture()
+{
+    std::vector<Point> points1 = {
+        Point(x1, y1),
+        Point(x2, y2),
+        Point(x3, y3),
+        Point(x4, y4),
+        Point(x1, y1),
+    };
+    Polygon polygon1 = make<Polygon>(points1);
+
+    std::vector<Point> points2 = {
+        Point(x5, y5),
+        Point(x6, y6),
+        Point(x7, y7),
+        Point(x8, y8),
+        Point(x5, y5),
+    };
+    Polygon polygon2 = make<Polygon>(points2);
+
+    std::vector<Polygon> polygons = {
+        polygon1,
+        polygon2
+    };
+    multiPolygon = makeMulti<MultiPolygon>(polygons);
+}

--- a/test/geometry/modelsfixture.h
+++ b/test/geometry/modelsfixture.h
@@ -1,0 +1,89 @@
+#ifndef MODELSFIXTURE_H
+#define MODELSFIXTURE_H
+
+#include <ophidian/geometry/Models.h>
+
+struct PointFixture {
+    double x = 1.0;
+    double y = 2.0;
+
+    ophidian::geometry::Point point;
+
+    PointFixture();
+};
+
+struct SegmentFixture {
+    double x1 = 1.0;
+    double y1 = 2.0;
+    double x2 = 2.0;
+    double y2 = 1.0;
+
+    ophidian::geometry::Segment segment;
+
+    SegmentFixture();
+};
+
+struct LinestringFixture {
+    double x1 = 1.0;
+    double y1 = 2.0;
+    double x2 = 2.0;
+    double y2 = 1.0;
+    double x3 = 2.0;
+    double y3 = 2.0;
+
+    ophidian::geometry::Linestring linestring;
+
+    LinestringFixture();
+};
+
+struct BoxFixture {
+    double xMin = 1.0;
+    double yMin = 2.0;
+    double xMax = 2.0;
+    double yMax = 2.0;
+
+    ophidian::geometry::Box box;
+
+    BoxFixture();
+};
+
+struct PolygonFixture {
+    double x1 = 1.0;
+    double y1 = 1.0;
+    double x2 = 2.0;
+    double y2 = 1.0;
+    double x3 = 2.0;
+    double y3 = 2.0;
+    double x4 = 1.0;
+    double y4 = 2.0;
+
+    ophidian::geometry::Polygon polygon;
+
+    PolygonFixture();
+};
+
+struct MultiPolygonFixture {
+    double x1 = 1.0;
+    double y1 = 1.0;
+    double x2 = 2.0;
+    double y2 = 1.0;
+    double x3 = 2.0;
+    double y3 = 2.0;
+    double x4 = 1.0;
+    double y4 = 2.0;
+
+    double x5 = 3.0;
+    double y5 = 1.0;
+    double x6 = 4.0;
+    double y6 = 1.0;
+    double x7 = 4.0;
+    double y7 = 2.0;
+    double x8 = 3.0;
+    double y8 = 2.0;
+
+    ophidian::geometry::MultiPolygon multiPolygon;
+
+    MultiPolygonFixture();
+};
+
+#endif // MODELSFIXTURE_H

--- a/test/geometry/rotationtest.cpp
+++ b/test/geometry/rotationtest.cpp
@@ -1,0 +1,122 @@
+#include <catch.hpp>
+
+#include <ophidian/geometry/Operations.h>
+
+#include "modelsfixture.h"
+
+using namespace ophidian::geometry;
+
+TEST_CASE("Geometry: rotating a Point", "[geometry][operations]") {
+    double degree = 90;
+
+    PointFixture pointFixture;
+
+    Point rotatedPoint;
+    rotate(pointFixture.point, degree, rotatedPoint);
+
+    REQUIRE(rotatedPoint.x() == Approx(2.0));
+    REQUIRE(rotatedPoint.y() == Approx(-1.0));
+}
+
+TEST_CASE("Geometry: rotating a Segment", "[geometry][operations]") {
+    double degree = 90;
+
+    SegmentFixture segmentFixture;
+
+    Segment rotatedSegment;
+    rotate(segmentFixture.segment, degree, rotatedSegment);
+
+    REQUIRE(rotatedSegment.first.x() == Approx(2.0));
+    REQUIRE(rotatedSegment.first.y() == Approx(-1.0));
+    REQUIRE(rotatedSegment.second.x() == Approx(1.0));
+    REQUIRE(rotatedSegment.second.y() == Approx(-2.0));
+}
+
+TEST_CASE("Geometry: rotating a Linestring", "[geometry][operations]") {
+    double degree = 90;
+
+    LinestringFixture linestringFixture;
+
+    Linestring rotatedLinestring;
+    rotate(linestringFixture.linestring, degree, rotatedLinestring);
+
+    std::vector<Point> linestringPoints(rotatedLinestring.begin(), rotatedLinestring.end());
+    REQUIRE(linestringPoints.size() == 3);
+    REQUIRE(linestringPoints.at(0).x() == Approx(2.0));
+    REQUIRE(linestringPoints.at(0).y() == Approx(-1.0));
+    REQUIRE(linestringPoints.at(1).x() == Approx(1.0));
+    REQUIRE(linestringPoints.at(1).y() == Approx(-2.0));
+    REQUIRE(linestringPoints.at(2).x() == Approx(2.0));
+    REQUIRE(linestringPoints.at(2).y() == Approx(-2.0));
+}
+
+TEST_CASE("Geometry: rotating a Box", "[geometry][operations]") {
+    double degree = 90;
+
+    BoxFixture boxFixture;
+
+    Box rotatedBox;
+    rotate(boxFixture.box, degree, rotatedBox);
+
+    REQUIRE(rotatedBox.min_corner().x() == Approx(2.0));
+    REQUIRE(rotatedBox.min_corner().y() == Approx(-2.0));
+    REQUIRE(rotatedBox.max_corner().x() == Approx(2.0));
+    REQUIRE(rotatedBox.max_corner().y() == Approx(-1.0));
+}
+
+TEST_CASE("Geometry: rotating a Polygon", "[geometry][operations]") {
+    double degree = 90;
+
+    PolygonFixture polygonFixture;
+
+    Polygon rotatedPolygon;
+    rotate(polygonFixture.polygon, degree, rotatedPolygon);
+
+    std::vector<Point> polygonPoints(rotatedPolygon.outer().begin(), rotatedPolygon.outer().end());
+    REQUIRE(polygonPoints.size() == 5);
+    REQUIRE(polygonPoints.at(0).x() == Approx(1.0));
+    REQUIRE(polygonPoints.at(0).y() == Approx(-1.0));
+    REQUIRE(polygonPoints.at(1).x() == Approx(1.0));
+    REQUIRE(polygonPoints.at(1).y() == Approx(-2.0));
+    REQUIRE(polygonPoints.at(2).x() == Approx(2.0));
+    REQUIRE(polygonPoints.at(2).y() == Approx(-2.0));
+    REQUIRE(polygonPoints.at(3).x() == Approx(2.0));
+    REQUIRE(polygonPoints.at(3).y() == Approx(-1.0));
+    REQUIRE(polygonPoints.at(4).x() == Approx(1.0));
+    REQUIRE(polygonPoints.at(4).y() == Approx(-1.0));
+}
+
+TEST_CASE("Geometry: rotating a MultiPolygon", "[geometry][operations]") {
+    double degree = 90;
+
+    MultiPolygonFixture multiPolygonFixture;
+
+    MultiPolygon rotatedMultiPolygon;
+    rotate(multiPolygonFixture.multiPolygon, degree, rotatedMultiPolygon);
+
+    std::vector<Point> polygon1Points(rotatedMultiPolygon.at(0).outer().begin(), rotatedMultiPolygon.at(0).outer().end());
+    REQUIRE(polygon1Points.size() == 5);
+    REQUIRE(polygon1Points.at(0).x() == Approx(1.0));
+    REQUIRE(polygon1Points.at(0).y() == Approx(-1.0));
+    REQUIRE(polygon1Points.at(1).x() == Approx(1.0));
+    REQUIRE(polygon1Points.at(1).y() == Approx(-2.0));
+    REQUIRE(polygon1Points.at(2).x() == Approx(2.0));
+    REQUIRE(polygon1Points.at(2).y() == Approx(-2.0));
+    REQUIRE(polygon1Points.at(3).x() == Approx(2.0));
+    REQUIRE(polygon1Points.at(3).y() == Approx(-1.0));
+    REQUIRE(polygon1Points.at(4).x() == Approx(1.0));
+    REQUIRE(polygon1Points.at(4).y() == Approx(-1.0));
+
+    std::vector<Point> polygon2Points(rotatedMultiPolygon.at(1).outer().begin(), rotatedMultiPolygon.at(1).outer().end());
+    REQUIRE(polygon2Points.size() == 5);
+    REQUIRE(polygon2Points.at(0).x() == Approx(1.0));
+    REQUIRE(polygon2Points.at(0).y() == Approx(-3.0));
+    REQUIRE(polygon2Points.at(1).x() == Approx(1.0));
+    REQUIRE(polygon2Points.at(1).y() == Approx(-4.0));
+    REQUIRE(polygon2Points.at(2).x() == Approx(2.0));
+    REQUIRE(polygon2Points.at(2).y() == Approx(-4.0));
+    REQUIRE(polygon2Points.at(3).x() == Approx(2.0));
+    REQUIRE(polygon2Points.at(3).y() == Approx(-3.0));
+    REQUIRE(polygon2Points.at(4).x() == Approx(1.0));
+    REQUIRE(polygon2Points.at(4).y() == Approx(-3.0));
+}

--- a/test/geometry/scalingtest.cpp
+++ b/test/geometry/scalingtest.cpp
@@ -1,0 +1,122 @@
+#include <catch.hpp>
+
+#include <ophidian/geometry/Operations.h>
+
+#include "modelsfixture.h"
+
+using namespace ophidian::geometry;
+
+TEST_CASE("Geometry: scaling a Point", "[geometry][operations]") {
+    Point scalingPoint(2.0, 2.0);
+
+    PointFixture pointFixture;
+
+    Point scaledPoint;
+    scale(pointFixture.point, scalingPoint, scaledPoint);
+
+    REQUIRE(scaledPoint.x() == pointFixture.x * scalingPoint.x());
+    REQUIRE(scaledPoint.y() == pointFixture.y * scalingPoint.y());
+}
+
+TEST_CASE("Geometry: scaling a Segment", "[geometry][operations]") {
+    Point scalingPoint(2.0, 2.0);
+
+    SegmentFixture segmentFixture;
+
+    Segment scaledSegment;
+    scale(segmentFixture.segment, scalingPoint, scaledSegment);
+
+    REQUIRE(scaledSegment.first.x() == segmentFixture.x1 * scalingPoint.x());
+    REQUIRE(scaledSegment.first.y() == segmentFixture.y1 * scalingPoint.y());
+    REQUIRE(scaledSegment.second.x() == segmentFixture.x2 * scalingPoint.x());
+    REQUIRE(scaledSegment.second.y() == segmentFixture.y2 * scalingPoint.y());
+}
+
+TEST_CASE("Geometry: scaling a Linestring", "[geometry][operations]") {
+    Point scalingPoint(2.0, 2.0);
+
+    LinestringFixture linestringFixture;
+
+    Linestring scaledLinestring;
+    scale(linestringFixture.linestring, scalingPoint, scaledLinestring);
+
+    std::vector<Point> linestringPoints(scaledLinestring.begin(), scaledLinestring.end());
+    REQUIRE(linestringPoints.size() == 3);
+    REQUIRE(linestringPoints.at(0).x() == linestringFixture.x1 * scalingPoint.x());
+    REQUIRE(linestringPoints.at(0).y() == linestringFixture.y1 * scalingPoint.y());
+    REQUIRE(linestringPoints.at(1).x() == linestringFixture.x2 * scalingPoint.x());
+    REQUIRE(linestringPoints.at(1).y() == linestringFixture.y2 * scalingPoint.y());
+    REQUIRE(linestringPoints.at(2).x() == linestringFixture.x3 * scalingPoint.x());
+    REQUIRE(linestringPoints.at(2).y() == linestringFixture.y3 * scalingPoint.y());
+}
+
+TEST_CASE("Geometry: scaling a Box", "[geometry][operations]") {
+    Point scalingPoint(2.0, 2.0);
+
+    BoxFixture boxFixture;
+
+    Box scaledBox;
+    scale(boxFixture.box, scalingPoint, scaledBox);
+
+    REQUIRE(scaledBox.min_corner().x() == boxFixture.xMin * scalingPoint.x());
+    REQUIRE(scaledBox.min_corner().y() == boxFixture.yMin * scalingPoint.y());
+    REQUIRE(scaledBox.max_corner().x() == boxFixture.xMax * scalingPoint.x());
+    REQUIRE(scaledBox.max_corner().y() == boxFixture.yMax * scalingPoint.y());
+}
+
+TEST_CASE("Geometry: scaling a Polygon", "[geometry][operations]") {
+    Point scalingPoint(2.0, 2.0);
+
+    PolygonFixture polygonFixture;
+
+    Polygon scaledPolygon;
+    scale(polygonFixture.polygon, scalingPoint, scaledPolygon);
+
+    std::vector<Point> polygonPoints(scaledPolygon.outer().begin(), scaledPolygon.outer().end());
+    REQUIRE(polygonPoints.size() == 5);
+    REQUIRE(polygonPoints.at(0).x() == polygonFixture.x1 * scalingPoint.x());
+    REQUIRE(polygonPoints.at(0).y() == polygonFixture.y1 * scalingPoint.y());
+    REQUIRE(polygonPoints.at(1).x() == polygonFixture.x2 * scalingPoint.x());
+    REQUIRE(polygonPoints.at(1).y() == polygonFixture.y2 * scalingPoint.y());
+    REQUIRE(polygonPoints.at(2).x() == polygonFixture.x3 * scalingPoint.x());
+    REQUIRE(polygonPoints.at(2).y() == polygonFixture.y3 * scalingPoint.y());
+    REQUIRE(polygonPoints.at(3).x() == polygonFixture.x4 * scalingPoint.x());
+    REQUIRE(polygonPoints.at(3).y() == polygonFixture.y4 * scalingPoint.y());
+    REQUIRE(polygonPoints.at(4).x() == polygonFixture.x1 * scalingPoint.x());
+    REQUIRE(polygonPoints.at(4).y() == polygonFixture.y1 * scalingPoint.y());
+}
+
+TEST_CASE("Geometry: scaling a MultiPolygon", "[geometry][operations]") {
+    Point scalingPoint(2.0, 2.0);
+
+    MultiPolygonFixture multiPolygonFixture;
+
+    MultiPolygon scaledMultiPolygon;
+    scale(multiPolygonFixture.multiPolygon, scalingPoint, scaledMultiPolygon);
+
+    std::vector<Point> polygon1Points(scaledMultiPolygon.at(0).outer().begin(), scaledMultiPolygon.at(0).outer().end());
+    REQUIRE(polygon1Points.size() == 5);
+    REQUIRE(polygon1Points.at(0).x() == multiPolygonFixture.x1 * scalingPoint.x());
+    REQUIRE(polygon1Points.at(0).y() == multiPolygonFixture.y1 * scalingPoint.y());
+    REQUIRE(polygon1Points.at(1).x() == multiPolygonFixture.x2 * scalingPoint.x());
+    REQUIRE(polygon1Points.at(1).y() == multiPolygonFixture.y2 * scalingPoint.y());
+    REQUIRE(polygon1Points.at(2).x() == multiPolygonFixture.x3 * scalingPoint.x());
+    REQUIRE(polygon1Points.at(2).y() == multiPolygonFixture.y3 * scalingPoint.y());
+    REQUIRE(polygon1Points.at(3).x() == multiPolygonFixture.x4 * scalingPoint.x());
+    REQUIRE(polygon1Points.at(3).y() == multiPolygonFixture.y4 * scalingPoint.y());
+    REQUIRE(polygon1Points.at(4).x() == multiPolygonFixture.x1 * scalingPoint.x());
+    REQUIRE(polygon1Points.at(4).y() == multiPolygonFixture.y1 * scalingPoint.y());
+
+    std::vector<Point> polygon2Points(scaledMultiPolygon.at(1).outer().begin(), scaledMultiPolygon.at(1).outer().end());
+    REQUIRE(polygon2Points.size() == 5);
+    REQUIRE(polygon2Points.at(0).x() == multiPolygonFixture.x5 * scalingPoint.x());
+    REQUIRE(polygon2Points.at(0).y() == multiPolygonFixture.y5 * scalingPoint.y());
+    REQUIRE(polygon2Points.at(1).x() == multiPolygonFixture.x6 * scalingPoint.x());
+    REQUIRE(polygon2Points.at(1).y() == multiPolygonFixture.y6 * scalingPoint.y());
+    REQUIRE(polygon2Points.at(2).x() == multiPolygonFixture.x7 * scalingPoint.x());
+    REQUIRE(polygon2Points.at(2).y() == multiPolygonFixture.y7 * scalingPoint.y());
+    REQUIRE(polygon2Points.at(3).x() == multiPolygonFixture.x8 * scalingPoint.x());
+    REQUIRE(polygon2Points.at(3).y() == multiPolygonFixture.y8 * scalingPoint.y());
+    REQUIRE(polygon2Points.at(4).x() == multiPolygonFixture.x5 * scalingPoint.x());
+    REQUIRE(polygon2Points.at(4).y() == multiPolygonFixture.y5 * scalingPoint.y());
+}

--- a/test/geometry/translationtest.cpp
+++ b/test/geometry/translationtest.cpp
@@ -1,0 +1,122 @@
+#include <catch.hpp>
+
+#include <ophidian/geometry/Operations.h>
+
+#include "modelsfixture.h"
+
+using namespace ophidian::geometry;
+
+TEST_CASE("Geometry: translating a Point", "[geometry][operations]") {
+    Point translationPoint(1.0, 1.0);
+
+    PointFixture pointFixture;
+
+    Point translatedPoint;
+    translate(pointFixture.point, translationPoint, translatedPoint);
+
+    REQUIRE(translatedPoint.x() == pointFixture.x + translationPoint.x());
+    REQUIRE(translatedPoint.y() == pointFixture.y + translationPoint.y());
+}
+
+TEST_CASE("Geometry: translating a Segment", "[geometry][operations]") {
+    Point translationPoint(1.0, 1.0);
+
+    SegmentFixture segmentFixture;
+
+    Segment translatedSegment;
+    translate(segmentFixture.segment, translationPoint, translatedSegment);
+
+    REQUIRE(translatedSegment.first.x() == segmentFixture.x1 + translationPoint.x());
+    REQUIRE(translatedSegment.first.y() == segmentFixture.y1 + translationPoint.y());
+    REQUIRE(translatedSegment.second.x() == segmentFixture.x2 + translationPoint.x());
+    REQUIRE(translatedSegment.second.y() == segmentFixture.y2 + translationPoint.y());
+}
+
+TEST_CASE("Geometry: translating a Linestring", "[geometry][operations]") {
+    Point translationPoint(1.0, 1.0);
+
+    LinestringFixture linestringFixture;
+
+    Linestring translatedLinestring;
+    translate(linestringFixture.linestring, translationPoint, translatedLinestring);
+
+    std::vector<Point> linestringPoints(translatedLinestring.begin(), translatedLinestring.end());
+    REQUIRE(linestringPoints.size() == 3);
+    REQUIRE(linestringPoints.at(0).x() == linestringFixture.x1 + translationPoint.x());
+    REQUIRE(linestringPoints.at(0).y() == linestringFixture.y1 + translationPoint.y());
+    REQUIRE(linestringPoints.at(1).x() == linestringFixture.x2 + translationPoint.x());
+    REQUIRE(linestringPoints.at(1).y() == linestringFixture.y2 + translationPoint.y());
+    REQUIRE(linestringPoints.at(2).x() == linestringFixture.x3 + translationPoint.x());
+    REQUIRE(linestringPoints.at(2).y() == linestringFixture.y3 + translationPoint.y());
+}
+
+TEST_CASE("Geometry: translating a Box", "[geometry][operations]") {
+    Point translationPoint(1.0, 1.0);
+
+    BoxFixture boxFixture;
+
+    Box translatedBox;
+    translate(boxFixture.box, translationPoint, translatedBox);
+
+    REQUIRE(translatedBox.min_corner().x() == boxFixture.xMin + translationPoint.x());
+    REQUIRE(translatedBox.min_corner().y() == boxFixture.yMin + translationPoint.y());
+    REQUIRE(translatedBox.max_corner().x() == boxFixture.xMax + translationPoint.x());
+    REQUIRE(translatedBox.max_corner().y() == boxFixture.yMax + translationPoint.y());
+}
+
+TEST_CASE("Geometry: translating a Polygon", "[geometry][operations]") {
+    Point translationPoint(1.0, 1.0);
+
+    PolygonFixture polygonFixture;
+
+    Polygon translatedPolygon;
+    translate(polygonFixture.polygon, translationPoint, translatedPolygon);
+
+    std::vector<Point> polygonPoints(translatedPolygon.outer().begin(), translatedPolygon.outer().end());
+    REQUIRE(polygonPoints.size() == 5);
+    REQUIRE(polygonPoints.at(0).x() == polygonFixture.x1 + translationPoint.x());
+    REQUIRE(polygonPoints.at(0).y() == polygonFixture.y1 + translationPoint.y());
+    REQUIRE(polygonPoints.at(1).x() == polygonFixture.x2 + translationPoint.x());
+    REQUIRE(polygonPoints.at(1).y() == polygonFixture.y2 + translationPoint.y());
+    REQUIRE(polygonPoints.at(2).x() == polygonFixture.x3 + translationPoint.x());
+    REQUIRE(polygonPoints.at(2).y() == polygonFixture.y3 + translationPoint.y());
+    REQUIRE(polygonPoints.at(3).x() == polygonFixture.x4 + translationPoint.x());
+    REQUIRE(polygonPoints.at(3).y() == polygonFixture.y4 + translationPoint.y());
+    REQUIRE(polygonPoints.at(4).x() == polygonFixture.x1 + translationPoint.x());
+    REQUIRE(polygonPoints.at(4).y() == polygonFixture.y1 + translationPoint.y());
+}
+
+TEST_CASE("Geometry: translating a MultiPolygon", "[geometry][operations]") {
+    Point translationPoint(1.0, 1.0);
+
+    MultiPolygonFixture multiPolygonFixture;
+
+    MultiPolygon translatedMultiPolygon;
+    translate(multiPolygonFixture.multiPolygon, translationPoint, translatedMultiPolygon);
+
+    std::vector<Point> polygon1Points(translatedMultiPolygon.at(0).outer().begin(), translatedMultiPolygon.at(0).outer().end());
+    REQUIRE(polygon1Points.size() == 5);
+    REQUIRE(polygon1Points.at(0).x() == multiPolygonFixture.x1 + translationPoint.x());
+    REQUIRE(polygon1Points.at(0).y() == multiPolygonFixture.y1 + translationPoint.y());
+    REQUIRE(polygon1Points.at(1).x() == multiPolygonFixture.x2 + translationPoint.x());
+    REQUIRE(polygon1Points.at(1).y() == multiPolygonFixture.y2 + translationPoint.y());
+    REQUIRE(polygon1Points.at(2).x() == multiPolygonFixture.x3 + translationPoint.x());
+    REQUIRE(polygon1Points.at(2).y() == multiPolygonFixture.y3 + translationPoint.y());
+    REQUIRE(polygon1Points.at(3).x() == multiPolygonFixture.x4 + translationPoint.x());
+    REQUIRE(polygon1Points.at(3).y() == multiPolygonFixture.y4 + translationPoint.y());
+    REQUIRE(polygon1Points.at(4).x() == multiPolygonFixture.x1 + translationPoint.x());
+    REQUIRE(polygon1Points.at(4).y() == multiPolygonFixture.y1 + translationPoint.y());
+
+    std::vector<Point> polygon2Points(translatedMultiPolygon.at(1).outer().begin(), translatedMultiPolygon.at(1).outer().end());
+    REQUIRE(polygon2Points.size() == 5);
+    REQUIRE(polygon2Points.at(0).x() == multiPolygonFixture.x5 + translationPoint.x());
+    REQUIRE(polygon2Points.at(0).y() == multiPolygonFixture.y5 + translationPoint.y());
+    REQUIRE(polygon2Points.at(1).x() == multiPolygonFixture.x6 + translationPoint.x());
+    REQUIRE(polygon2Points.at(1).y() == multiPolygonFixture.y6 + translationPoint.y());
+    REQUIRE(polygon2Points.at(2).x() == multiPolygonFixture.x7 + translationPoint.x());
+    REQUIRE(polygon2Points.at(2).y() == multiPolygonFixture.y7 + translationPoint.y());
+    REQUIRE(polygon2Points.at(3).x() == multiPolygonFixture.x8 + translationPoint.x());
+    REQUIRE(polygon2Points.at(3).y() == multiPolygonFixture.y8 + translationPoint.y());
+    REQUIRE(polygon2Points.at(4).x() == multiPolygonFixture.x5 + translationPoint.x());
+    REQUIRE(polygon2Points.at(4).y() == multiPolygonFixture.y5 + translationPoint.y());
+}


### PR DESCRIPTION
This adds a Geometry module to ophidian. The geometry module contains models for points, segments, linestrings, boxes, polygons and multi polygons. It also defines distance metrics and operations such as translation, scaling, rotation and intersection. I also changed the .travis.yml file to install boost 1.59, since it is required to compile this module.
