### PR TITLE
Fixing mac errors 2.0

### DIFF
--- a/ophidian/geometry/CMakeLists.txt
+++ b/ophidian/geometry/CMakeLists.txt
@@ -2,8 +2,8 @@ file(GLOB ophidian_geometry_SRC
     "*.h"
     "*.cpp"
 )
-include_directories(${Boost_INCLUDE_DIRS})
 add_library(ophidian_geometry ${ophidian_geometry_SRC})
 target_link_libraries(ophidian_geometry PUBLIC )
+target_include_directories(ophidian_geometry PUBLIC ${Boost_INCLUDE_DIRS})
 install(TARGETS ophidian_geometry DESTINATION lib)
 install(FILES Distance.h Models.h Operations.h DESTINATION include/ophidian/geometry)


### PR DESCRIPTION
I'm opening this PR because it seems to me that `include_directories` conflicts with `target_include_directories`. For the next PRs: please, avoid using `include_directories`.
