### PR TITLE
Removed CLang from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,6 @@ matrix:
           packages:
             - g++-5
       env: COMPILER=g++-5
-    - compiler: clang
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.7
-          packages:
-            - clang-3.7
-      env: COMPILER=clang++-3.7
       
 before_script:
   - mkdir build && cd build


### PR DESCRIPTION
CLang is not working as expected. Since it's blocking PRs and we don't have enough HR to support such compiler, I'm removing it from Travis in this PR.