### PR TITLE
Fixing bug when erasing entity from entity system

### DIFF
--- a/ophidian/entity_system/EntitySystem.h
+++ b/ophidian/entity_system/EntitySystem.h
@@ -154,16 +154,17 @@ public:
 	   \param entity A handler for the Entity to erase.
 	   \brief Erases an Entity instance as well as its atached Properties.
 	 */
-	void erase(const Entity& entity)
-	{
-		notifier_.erase(entity);
-		auto index = id(entity);
-		auto lastEntityId = id(container_.back());
-		std::swap(container_[index], container_.back());
-		container_.pop_back();
-		id2Index_[lastEntityId] = index;
-		id2Index_[index] = std::numeric_limits<uint32_t>::max();
-	}
+    void erase(const Entity& entity)
+    {
+        notifier_.erase(entity);
+        auto entityId = EntitySystemBase::id(entity);
+        auto index = id(entity);
+        auto lastEntityId = EntitySystemBase::id(container_.back());
+        std::swap(container_[index], container_.back());
+        container_.pop_back();
+        id2Index_[lastEntityId] = index;
+        id2Index_[entityId] = std::numeric_limits<uint32_t>::max();
+    }
 	//! Clear Entities
 	/*!
 	   \brief Erases all Entities as well as its atached Properties.

--- a/test/entity_system/property_test.cpp
+++ b/test/entity_system/property_test.cpp
@@ -156,5 +156,31 @@ TEST_CASE("Property: property capacity", "[entity_system][Property]") {
 
 }
 
+TEST_CASE("Property: accessing property after erasing entity", "[entity_system][Property]") {
+    EntitySystem<MyEntity> sys;
+    auto en1 = sys.add();
+    auto en2 = sys.add();
+
+    Property<MyEntity, int> prop(sys);
+    prop[en1] = 1;
+    prop[en2] = 2;
+
+    REQUIRE(prop[en1] == 1);
+    REQUIRE(prop[en2] == 2);
+
+    sys.erase(en1);
+
+    auto en3 = sys.add();
+
+    prop[en3] = 3;
+
+    REQUIRE(prop[en2] == 2);
+    REQUIRE(prop[en3] == 3);
+
+    sys.erase(en2);
+
+    REQUIRE(prop[en3] == 3);
+}
+
 
 


### PR DESCRIPTION
This should fix the spotted bug when erasing entities. I added a test in property_test.cpp to verify this. The test was failing before my modification.