### PR TITLE
Update parser InexistentFile exception

### DIFF
--- a/ophidian/parser/Def.cpp
+++ b/ophidian/parser/Def.cpp
@@ -24,7 +24,7 @@ namespace ophidian
 namespace parser
 {
 
-std::unique_ptr<Def> DefParser::readFile(const std::string & filename) const throw(InexistentFile)
+std::unique_ptr<Def> DefParser::readFile(const std::string & filename) const
 {
 	auto def = std::make_unique<Def>();
 	defrInit();
@@ -79,7 +79,7 @@ std::unique_ptr<Def> DefParser::readFile(const std::string & filename) const thr
 		auto res = defrRead(ifp, filename.c_str(), def.get(), true);
 	}
 	else {
-		throw InexistentFile();
+		throw InexistentFile(filename);
 	}
 
 	fclose(ifp);

--- a/ophidian/parser/Def.h
+++ b/ophidian/parser/Def.h
@@ -150,7 +150,7 @@ public:
 	DefParser();
 	~DefParser();
 
-	std::unique_ptr<Def> readFile(const std::string & filename) const throw(InexistentFile);
+	std::unique_ptr<Def> readFile(const std::string & filename) const;
 };
 } // namespace parser
 } // namespace ophidian

--- a/ophidian/parser/Lef.cpp
+++ b/ophidian/parser/Lef.cpp
@@ -65,7 +65,7 @@ void LefParser::readFile(const std::string &filename, std::unique_ptr<ophidian::
 
 	if (!fp)
 	{
-		throw InexistentFile();
+		throw InexistentFile(filename);
 	}
 
 	lefrInit();

--- a/ophidian/parser/ParserException.h
+++ b/ophidian/parser/ParserException.h
@@ -19,19 +19,17 @@
 #ifndef PARSER_EXCEPTION_H
 #define PARSER_EXCEPTION_H
 
-#include <exception>
+#include <stdexcept>
 
 namespace ophidian
 {
 namespace parser
 {
 
-class InexistentFile : public std::exception
-{
+class InexistentFile : public std::runtime_error {
 public:
-	const char* what() const noexcept override {
-		return "The given file was not found";
-	}
+	InexistentFile() : std::runtime_error("The given file was not found") { }
+	InexistentFile(std::string file) : std::runtime_error("The file \"" + file + "\" was not found") { }
 };
 } // namespace parser
 } // namespace ophidian

--- a/test/parser/parserException_test.cpp
+++ b/test/parser/parserException_test.cpp
@@ -3,7 +3,7 @@
 #include <ophidian/parser/ParserException.h>
 
 namespace test {
-    void throwsInexistentFile() throw(ophidian::parser::InexistentFile) {
+    void throwsInexistentFile() {
         throw ophidian::parser::InexistentFile();
     }
 }


### PR DESCRIPTION
Remove throw(X) statement from function prototypes to stop the deprecated warnings

Change InexistentFile to inherit from std::runtime_error

Add parameter to InexistentFile to allow specifying which file was not found