### PR TITLE
Changing DesignBuilder

### DIFF
--- a/ophidian/design/DesignBuilder.cpp
+++ b/ophidian/design/DesignBuilder.cpp
@@ -21,7 +21,7 @@
 namespace ophidian
 {
 
-namespace designBuilder
+namespace design
 {
 
 ICCAD2017ContestDesignBuilder::ICCAD2017ContestDesignBuilder(const std::string & cellLefFile, const std::string & techLefFile, const std::string & placedDefFile) :
@@ -41,7 +41,7 @@ ICCAD2017ContestDesignBuilder::~ICCAD2017ContestDesignBuilder()
 
 }
 
-void ICCAD2017ContestDesignBuilder::build()
+Design & ICCAD2017ContestDesignBuilder::build()
 {
 	parser::LefParser lefParser;
 	parser::DefParser defParser;
@@ -57,7 +57,7 @@ void ICCAD2017ContestDesignBuilder::build()
 	placement::lef2Library(*mLef, mDesign.library(), mDesign.standardCells());
 	circuit::def2LibraryMapping(*mDef, mDesign.netlist(), mDesign.standardCells(), mDesign.libraryMapping());
 
-
+    return mDesign;
 }
 
 
@@ -79,7 +79,7 @@ ICCAD2015ContestDesignBuilder::~ICCAD2015ContestDesignBuilder()
 
 }
 
-void ICCAD2015ContestDesignBuilder::build()
+Design & ICCAD2015ContestDesignBuilder::build()
 {
 	parser::LefParser lefParser;
 	parser::DefParser defParser;
@@ -97,8 +97,10 @@ void ICCAD2015ContestDesignBuilder::build()
 	floorplan::lefDef2Floorplan(*mLef, *mDef, mDesign.floorplan());
 	placement::def2placement(*mDef, mDesign.placement(), mDesign.netlist());
 	circuit::verilog2Netlist(*mVerilog, mDesign.netlist());
+
+    return mDesign;
 }
 
-} //namespace designBuilder
+} //namespace design
 
 } //namespace ophidian

--- a/ophidian/design/DesignBuilder.h
+++ b/ophidian/design/DesignBuilder.h
@@ -33,13 +33,13 @@ namespace ophidian
 {
 
 /// Creates a design using an input file
-namespace designBuilder
+namespace design
 {
 
 class DesignBuilder
 {
 public:
-	virtual void build() = 0;
+    virtual Design & build() = 0;
 };
 
 
@@ -61,21 +61,10 @@ public:
 
 	//! build a system with ICCAD2017 files
 	/*!
-	   \brief build a system using 2 Lef and one Def as parameters
+       \brief build a system using 2 Lef and one Def as parameters and return the Design.
+       \return Design.
 	 */
-	void build();
-
-	//! Design getter
-	/*!
-	   \brief Get the Design.
-	   \return Design.
-	 */
-
-	design::Design & design()
-	{
-		return mDesign;
-	}
-
+    Design & build();
 
 private:
 	design::Design mDesign;
@@ -106,21 +95,10 @@ public:
 
 	//! build a system with ICCAD2015 files
 	/*!
-	   \brief build a system using one verilog,one Lef and one Def as parameters
+       \brief build a system using one verilog,one Lef and one Def as parameters and return the Design.
+       \return Design.
 	 */
-	void build();
-
-	//! Design getter
-	/*!
-	   \brief Get the Design.
-	   \return Design.
-	 */
-
-	design::Design & design()
-	{
-		return mDesign;
-	}
-
+    Design & build();
 
 private:
 	design::Design mDesign;
@@ -132,7 +110,7 @@ private:
 	std::string mVerilogFile;
 };
 
-} //namespace designBuilder
+} //namespace design
 
 } //namespace ophidian
 

--- a/ophidian/design/DesignBuilder.h
+++ b/ophidian/design/DesignBuilder.h
@@ -61,7 +61,7 @@ public:
 
 	//! build a system with ICCAD2017 files
 	/*!
-       \brief build a system using 2 Lef and one Def as parameters and return the Design.
+       \brief build a system using 2 Lef and one Def as parameters.
        \return Design.
 	 */
     Design & build();
@@ -95,7 +95,7 @@ public:
 
 	//! build a system with ICCAD2015 files
 	/*!
-       \brief build a system using one verilog,one Lef and one Def as parameters and return the Design.
+       \brief build a system using one verilog,one Lef and one Def as parameters.
        \return Design.
 	 */
     Design & build();

--- a/test/design/designBuilder_test.cpp
+++ b/test/design/designBuilder_test.cpp
@@ -3,16 +3,16 @@
 
 #include <ophidian/design/DesignBuilder.h>
 
-using namespace ophidian::designBuilder;
+using namespace ophidian::design;
 
 TEST_CASE("DesignBuilder: building a 2017 design.", "[design]")
 {
 	ICCAD2017ContestDesignBuilder ICCAD2017DesignBuilder("./input_files/pci_bridge32_a_md1/cells_modified.lef",
 														 "./input_files/pci_bridge32_a_md1/tech.lef",
 														 "./input_files/pci_bridge32_a_md1/placed.def");
-	ICCAD2017DesignBuilder.build();
+    Design & design = ICCAD2017DesignBuilder.build();
 
-	REQUIRE(ICCAD2017DesignBuilder.design().netlist().size(ophidian::circuit::Cell()) == 29521);
+    REQUIRE(design.netlist().size(ophidian::circuit::Cell()) == 29521);
 }
 
 
@@ -21,9 +21,9 @@ TEST_CASE("DesignBuilder: building a 2015 design.", "[design]")
 	ICCAD2015ContestDesignBuilder ICCAD2015DesignBuilder("./input_files/superblue18/superblue18.lef",
 														 "./input_files/superblue18/superblue18.def",
 														 "./input_files/superblue18/superblue18.v");
-	ICCAD2015DesignBuilder.build();
-	REQUIRE(ICCAD2015DesignBuilder.design().netlist().size(ophidian::circuit::Cell()) == 768068);
-	REQUIRE(ICCAD2015DesignBuilder.design().netlist().size(ophidian::circuit::Pin()) == 2559143);
-	REQUIRE(ICCAD2015DesignBuilder.design().netlist().size(ophidian::circuit::Net()) == 771542);
+    Design & design = ICCAD2015DesignBuilder.build();
+    REQUIRE(design.netlist().size(ophidian::circuit::Cell()) == 768068);
+    REQUIRE(design.netlist().size(ophidian::circuit::Pin()) == 2559143);
+    REQUIRE(design.netlist().size(ophidian::circuit::Net()) == 771542);
 
 }


### PR DESCRIPTION
Moving the DesignBuilder into the namespace design.

Changing the build() method to return a Design, eliminating the need to use the design() method.